### PR TITLE
Fixes a typo in security.md

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -90,7 +90,7 @@ Some security best practices for applications that use Cedar are as follows:
    {: .note }
    >Here, "code injection" refers to injection of Cedar code, not arbitrary code execution. It is the responsibility of the Cedar library to prevent arbitrary code injection.
    
-   For For example, consider a policy dynamically created as shown here:
+   For example, consider a policy dynamically created as shown here:
    ```
    let src = "permit(" + input + ", Action::\"view\", resource) when { principal.level > 3 };"let policy = parse(src);addToPolicySet(policy);
    ```


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Fixes a typo in Security.md from: `For For example, ...` to `For example, ...`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
