### PR TITLE
Updates to suppport RFC 9 

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,10 +1,9 @@
 # Site wide configuration
 
-title: Cedar Policy Language Version 2.2 Reference Guide
+title: Cedar Policy Language Version 2.3 Reference Guide
 locale: en_US
 logo: images/Cedar1-green.png
 
-#remote_theme: pages-themes/modernist@v0.2.0
 remote_theme: just-the-docs/just-the-docs
 plugins:
 - jekyll-remote-theme #

--- a/docs/doc-history.md
+++ b/docs/doc-history.md
@@ -12,6 +12,7 @@ The following table describes major documentation updates for Cedar.
 
 | Change | Description | Date | 
 | --- |--- |--- |
+| 2.3 | Implements [RFC 9](https://github.com/cedar-policy/rfcs/pull/9) that disallows whitespace in identifiers | June 29, 2023 |
 | 2.2 | Changes to Cedar API that don't affect the policy language | May 30, 2023 | 
 | 2.1 | Changes to Cedar API that don't affect the policy language | May 25, 2023 | 
 | 2.0 | Initial release of the Cedar Policy Language Guide | May 10, 2023 | 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -31,7 +31,12 @@ A schema contains a declaration of a namespace and two JSON objects: `entityType
 
 ## `namespace`<a name="schema-namespace"></a>
 
-A [namespace](validation.md#validation-namespaces) identifies and defines a scope for all entity types and actions declared within it. The `namespace` is a string that uses double colons \(`::`\) as separators between its elements. A namespace is mandatory and consists of a comma-separated list of JSON objects within braces `{ }`. The following is an example of a `namespace`:
+A [namespace](validation.md#validation-namespaces) identifies and defines a scope for all entity types and actions declared within it. The `namespace` is a string that uses double colons \(`::`\) as separators between its elements. 
+
+{: .important }
+>The namespace name must be normalized and cannot include any embedded whitespace, such as spaces, newlines, control characters, or comments.  
+
+A namespace is mandatory and consists of a comma-separated list of JSON objects within braces `{ }`. The following is an example of a `namespace`:
 
 ```
 "My::Namespace": {
@@ -73,6 +78,9 @@ Each entry in the entity is a JSON object with the following properties.
 ### Entity type name<a name="schema-entitytypes-name"></a>
 
 Specifies the name of the entity type as a string. This type name must be an identifier, which is defined in the Cedar grammar as a sequence of alphanumeric characters, omitting any Cedar reserved words.  
+
+{: .important }
+>The entity type name must be normalized and cannot include any embedded whitespace, such as spaces, newlines, control characters, or comments.  
 
 ```
 "My::Name::Space": {


### PR DESCRIPTION
Implements [RFC 9](https://github.com/cedar-policy/rfcs/pull/9) whitespace in namespace and entity type names

*Description of changes:*
Added notes to the descriptions of namespace and entityType name to specify that they can't include any whitespace.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
