### PR TITLE
Terminology, schema, validation updates

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -26,8 +26,7 @@ You can use a schema to define each of the following entities used by your appli
 
 Services that use Cedar can use the information provided in the schema to validate the policies you submit to the policy store. This helps prevent your policies from returning incorrect authorization decisions because of errors in policies like incorrectly typed attribute names. For more information about validating your policies, see [Cedar policy validation against schema](validation.md).
 
-A schema contains a declaration of a namespace and two JSON objects: `entityTypes` and `actions`. 
-
+A schema contains a declaration of a namespace and two mandatory JSON objects, `entityTypes` and `actions`. The namespace can optionally include a third object, `commonTypes`, which defines types that can be referenced by the other two objects.
 
 ## `namespace`<a name="schema-namespace"></a>
 
@@ -46,13 +45,14 @@ A namespace is mandatory and consists of a comma-separated list of JSON objects 
 }
 ```
 
-A namespace can contain two child elements:
+A namespace must contain two child elements, and may contain a third, appearing in any order:
 + ``entityTypes``
 + ``actions``
++ ``commonTypes`` (optional)
 
-You define all of your principal types, resource types, and actions that apply to your application in these elements. Principals and resources are separated from actions into different elements because the `principal` and `resource` entities are defined as categories, or *types*. Later, you can instantiate these types as individual principals and resources. Actions are already individual discrete elements rather than types.
+You define the types of your application's principal and resource entities within the `entityTypes` element, and the specific actions in the `actions` element. Principals and resources are separated from actions because the `principal` and `resource` entities are defined as categories, or *types*. In your entity store you create individual principal and resource entities that have these types. Actions are defined in the schema as individual discrete elements directly (each of which has type `Action`). Optionally, you can define type names in `commonTypes` and reference those names as types in the `entityTypes` and `actions` elements of your schema.
 
-You can remove a namespace from the schema. If you do, you must also remove that namespace from the fully qualified names of the former namespace's types. If you don't, then Cedar can't resolve those types because the name is no longer valid.
+Note that if you change the namespace of your schema you will need to change the fully qualified types (like `My::Namespace::User`) that reference the namespace. If you don't, then the validator won't properly resolve those types because their names are no longer valid.
 
 ## `entityTypes`<a name="schema-entityTypes"></a>
 
@@ -73,7 +73,7 @@ The high-level structure of an `entityTypes` entry looks like the following exam
 }
 ```
 
-Each entry in the entity is a JSON object with the following properties.
+Each entry in the `entityTypes` is a JSON object with the following properties.
 
 ### Entity type name<a name="schema-entitytypes-name"></a>
 
@@ -98,7 +98,7 @@ This type name is qualified by its [namespace](#schema-namespace) to form a full
 
 ### `memberOfTypes`<a name="schema-entitytypes-memberOf"></a>
 
-Specifies a list of entity types that can be direct parents of entities of this type. Values in this list must be valid entity type identifiers declared in the schema. If the `memberOfTypes` element is empty or not defined, then entities of that entity type can't have any parents in the entity hierarchy. The following example shows that an entity of type `User` can be a member of a parent `UserGroup`.
+Specifies a list of entity types that can be direct parents of entities of this type. Values in this list must be valid entity type names declared in the schema. If the `memberOfTypes` element is empty or not defined, then entities of that entity type can't have any parents in the entity hierarchy. The following example shows that an entity of type `User` can have parents of type `UserGroup`.
 
 ```
 "entityTypes": {
@@ -123,9 +123,7 @@ If the parent type is part of the same namespace as the child type, then you can
 
 ### `shape`<a name="schema-entitytypes-shape"></a>
 
-Specifies the data type and attributes that are needed to define entities of this type. 
-
-The top level `shape` of an entity must have type `Record`, which is accompanied by a description of the entity's attributes. The following example shows a simple specification of the `User` entity type.
+Specifies the shape of the data stored in entities of this type. The `shape` element, if present, must have type `Record`, and be accompanied by a description of the entity's attributes. The following example shows a simple specification of the `User` entity type.
 
 ```
 "User" : {
@@ -143,7 +141,9 @@ The top level `shape` of an entity must have type `Record`, which is accompanied
 }
 ```
 
-Each attribute in the `attributes` portion must follow a particular format, as we describe next.
+Each attribute in the `attributes` portion of the `shape` record must follow the format described next.
+
+Note that if the `shape` element is omitted, then entities of the type being defined are assumed to have no data stored with them. This is equivalent to specifying a `Record` with `{}` for its attributes.
 
 ### Attribute specifications<a name="schema-attributes-specs"></a>
 
@@ -162,7 +162,7 @@ You can choose to specify whether an attribute is required or optional. By defau
         "required": true
     },
 ```
-You can make an attribute optional by adding `"required": false` to the attribute description. In this case, a policy should check for the attribute's presence by using the [has](syntax-operators.md#operator-has) operator before trying to access the attribute's value. If evaluation of a policy results in an attempt to access a non-existent attribute, Cedar generates an exception. The validator will flag the potential for such errors to occur. The following example shows an attribute called `jobLevel` that is an optional attribute for whatever entity it's part of. 
+You can make an attribute optional by adding `"required": false` to the attribute description. A policy should check for an optional attribute's presence by using the [`has`](syntax-operators.md#operator-has) operator before trying to access the attribute's value. If evaluation of a policy results in an attempt to access a non-existent attribute, Cedar generates an exception. The validator will flag the potential for such errors to occur. The following example shows an attribute called `jobLevel` that is an optional attribute for whatever entity it's part of.
 
 ```
 "jobLevel": { 
@@ -209,7 +209,7 @@ A record attribute has the same JSON format as the [entity `shape`'s record's at
 #### `Entity`<a name="schema-entitytypes-shape-entity"></a>
 {: .no_toc }
 
-For attributes of `"type": "Entity"`, you must also specify a `name` that identifies the entity type of this attribute. The type must be defined in the schema. For example, a resource entity might require an `Owner` element that specifies a `User`.
+For attributes of type `"Entity"`, you must also specify a `name` that identifies the entity type of this attribute. The entity type must be defined in the schema. For example, a resource entity might require an `Owner` element that specifies a `User`.
 
 ```
 "Document" : {
@@ -228,9 +228,9 @@ For attributes of `"type": "Entity"`, you must also specify a `name` that identi
 #### `Set`<a name="schema-entitytypes-shape-set"></a>
 {: .no_toc }
 
-For attributes with `"type": "Set"`, you must also specify an `element` that defines the properties of the members of the set. Each element is a JSON object that describes what each member of the set looks like.
+For attributes with type `"Set"`, you must also specify an `element` that defines the properties of the members of the set. Each element is a JSON object that describes what each member of the set looks like.
 
-An `element` must contain the structure with the same rules as an attribute. As an example, consider the following `Admins` entry which could be part of the `shape` record of an `Account` entity type. This `Admins` element is a set of entities of type `User` and could be used to define which users have administrator permissions in the account.
+An `element` must contain a structure formatted according to the same rules as an attribute. As an example, consider the following `Admins` entry which could be part of the `shape` record of an `Account` entity type. This `Admins` element is a set of entities of type `User` and could be used to define which users have administrator permissions in the account.
 
 ```
 "Group" : {
@@ -252,20 +252,18 @@ An `element` must contain the structure with the same rules as an attribute. As 
 #### `Extension`<a name="schema-entitytypes-shape-extension"></a>
 {: .no_toc }
 
-For attributes of `"type": "Extension"`, you must also specify the `name` of the specific extension type.
+For attributes of type `"Extension"`, you must also specify the `name` of the specific extension type.
 There are two extension types: `ipaddr` for IP address values, and `decimal` for decimal values.
-For example, an action may include an IP address in it's context.
+For example, a `Network` entity may include the IP address of its gateway.
 
 ```
-"view": {
-    "appliesTo": {
-        "context": {
-            "type": "Record",
-            "attributes": {
-                "ip": {
-                    "type": "Extension",
-                    "name": "ipaddr"
-                },
+"Network": {
+    "shape": {
+        "type": "Record",
+        "attributes": {
+            "gateway": {
+                "type": "Extension",
+                "name": "ipaddr"
             }
         }
     }
@@ -274,23 +272,21 @@ For example, an action may include an IP address in it's context.
 
 ## `actions`<a name="schema-actions"></a>
 
-A collection of the actions that are supported by your application. An action is some type of operation that must be authorized before a user can perform it. The `actions` element contains a comma-separated list of one or more JSON objects.
+A collection of the `Action` entities usable as actions in authorization requests submitted by your application. The `actions` element contains a comma-separated list of one or more JSON objects.
 
-The high-level structure of an `actions` entry looks like the following example.
+The high-level structure of an `actions` entry looks like the following.
 
 ```
 "actions": {
     "ActionName1": {
-        "attributes": {},
-        "memberOf": ["ActionGroupName1", "ActionGroupName2"],
+        "memberOf": ["ActionGroupName1",...],
         "appliesTo": {
-            "principalTypes": [],
-            "resourceTypes": [],
-        },
-        "ActionName2": {
-            "something": "something"
+            "principalTypes": ["PrincipalEntityType1",...],
+            "resourceTypes": ["ResourceEntityType1",...],
         }
-    }
+    },
+    "ActionName2": { ... },
+    ...
 }
 ```
 
@@ -298,7 +294,7 @@ You can add as many actions as your application requires.
 
 ### Action name<a name="schema-actions-name"></a>
 
-Specifies the identifier for the action as a string. The name of the action isn't a value but the heading for its own JSON object. This is an entity identifier rather than an entity type, so it can contain anything that would be valid inside a Cedar string.
+Specifies the identifier for the action entity, as a string. The name of the action isn't a value but the heading for its own JSON object. Since this is an [entity identifier](syntax-entity.md#entity-overview) (rather than an entity type, as in the `entityTypes` section) it can contain anything that would be valid inside a Cedar string.
 
 ```
 "actions": {
@@ -320,7 +316,9 @@ MyApplicationNamespace::Action::"ViewPhoto"
 
 ### `memberOf`<a name="schema-actions-memberOf"></a>
 
-Specifies an identifier for an action that represents an action group. The following schema snippet shows an action named `viewAlbum` that is a member of the action group called `viewImages`.
+Specifies a list of identifiers for groups the action is a member of. The `memberOf` component is optional. If omitted, it means the action is a member of no action groups.
+
+The following schema snippet shows an action named `viewAlbum` that is a member of the action group called `viewImages`.
 
 ```
 "actions": {
@@ -336,24 +334,43 @@ Specifies an identifier for an action that represents an action group. The follo
     }
 }
 ```
+Action groups are themselves actions, and thus must also be defined in the schema in the `actions` section; we'll see an example of that below.
 
 ### `appliesTo`<a name="schema-actions-appliesTo"></a>
 
-Specifies a JSON object containing two lists, `principalTypes` and `resourceTypes`, which contain the principal and resources entity types that the action can accompany in an authorization request.
-+ If the `appliesTo` property or either of the component lists are absent from the `actions` element object, then the action can appear in an authorization request with an entity of *any* type, or with an unspecified entity.
-+ Both the `principalTypes` and `resourceTypes` can be empty lists, which means that the associated action can't be used in an authorization request with any entities of that category.
+Specifies a JSON object containing two lists, `principalTypes` and `resourceTypes`, which contain the principal and resources entity types, respectively, that can accompany the action in an authorization request.
++ If the `principalTypes` component is omitted from the `appliesTo` element, then an authorization request with this action can have a principal entity of *any* type, or the unspecified entity. The same is true for `resourceTypes`, for a request's resource component. If the `appliesTo` component is omitted entirely, it's the same as if it were present with both `princpalTypes` and `resourceTypes` components omitted (i.e., a request can have both principal and resource entities of any type, or leave them unspecified).
++ If either the `principalTypes` or `resourceTypes` components is given with an empty list `[]`, the associated action is not permitted in an authorization request with *any* entities of that category. This effectively means that the action will not be used in an authorization request at all. This makes sense for actions that act as groups for other actions.
 
-The following example `actions` snippet shows two actions. The first action, `viewPhoto`, requires that a policy evaluating that action must reference a principal of type `User` and a resource of type `Photo`. The second action, `listAlbums`, requires that a policy evaluating that action must reference a principal of type `User` and a resource of type `Account`.
+The following example `actions` snippet shows three actions. The first action, `read`, is an action group for the other two. It cannot appear in an authorization request because its `principalTypes` and `resourceTypes` components are `[]`. The second action, `viewPhoto`, is a member of the `read` action group, and expects that any request with this action will have a principal entity of type `User` and a resource entity of type `Photo`. The third action, `listAlbums`, also a member of the `read` group, expects that a request with that action will have a principal entity of type `User` and a resource entity of type `Account`. Notice that for both of the latter two actions, the group membership requires the action name be fully qualified with its namespace; here, `My::Namespace` is assumed to be the namespace in which this `actions` component is being defined.
 
 ```
 "actions": {
+    "read": {
+        "appliesTo": {
+            "principalTypes": [],
+            "resourceTypes": []
+        }
+    },
     "viewPhoto": {
+        "memberOf": [
+            {
+                "id": "read",
+                "type": "My::Namespace::Action"
+            }
+        ],
         "appliesTo": {
             "principalTypes": [ "User" ],
             "resourceTypes": [ "Photo" ]
         }
     },
     "listAlbums": {
+        "memberOf": [
+            {
+                "id": "read",
+                "type": "My::Namespace::Action"
+            }
+        ],
         "appliesTo": {
             "principalTypes": [ "User" ],
             "resourceTypes": [ "Account" ]
@@ -364,9 +381,9 @@ The following example `actions` snippet shows two actions. The first action, `vi
 
 ### `context`<a name="schema-actions-context"></a>
 
-Specifies a JSON object in the same format as an entitie's `shape` property, which defines the attributes that can be present in the context record in authorization requests made with this action. Specifying a `context` enables Cedar to validate policies that attempt to reference those attributes.
+Specifies a JSON object in the same format as an entity's `shape` property, which defines the attributes that can be present in the context record in authorization requests made with this action. Specifying a `context` enables Cedar to validate policies that attempt to reference the `context` record's attributes.
 
-Each context entry consists of `type` and `attributes` objects. The `type` object is always of type `Record`. The `attributes` object is a JSON collection of attribute names, each containing a `type` specification for that attribute. For example, the following `context` snippet specifies that any request to perform the `SomeAction` operation must include a test for a Boolean attribute named `field1`. The policy can also test an integer `field2` and a string `field3`, though it's OK if they're not referenced in the policy's context section. Any policy that doesn't include a required attribute in the policy's `context` section fails validation. The `context` entry is optional, and if excluded it is assumed to be an empty `Record`.
+Each `context` entry consists of `type` and `attributes` objects. The `type` object is always the type `Record`. The `attributes` object has the same JSON format as the [entity `shape`'s record's attributes](#schema-attributes-specs). For example, the following `context` snippet specifies that any request to perform the `SomeAction` action must include a `Boolean` attribute named `field1` and a `Long`attribute named `field2`. Optionally, the `context` may include a third attribute `field3` which, if present, is a `String`. The `context` entry is optional, and if excluded it is assumed to be an empty `Record` (in which case policies that try to access attributes in `context` will produce validation errors).
 
 ```
 "actions": {
@@ -377,9 +394,10 @@ Each context entry consists of `type` and `attributes` objects. The `type` objec
             "context": {
                 "type": "Record",
                 "attributes": {
-                    "field1": { "type": "Boolean", "required": true },
+                    "field1": { "type": "Boolean" },
                     "field2": { "type": "Long" },
-                    "field3": { "type": "String" }
+                    "field3": { "type": "String",
+                                "required": false }
                 }
             }
         }
@@ -387,11 +405,13 @@ Each context entry consists of `type` and `attributes` objects. The `type` objec
 }
 ```
 
-## commonTypes - Reuse of common user-defined types
+## `commonTypes`
 
-Your schema might define several entity types that share a lot of elements in common. Instead of redundantly entering those elements separately for each entity that needs them, you can define those elements once using a `commonTypes` construct with a name, and then reference that construct's name in each entity that requires them. You can use this anywhere you can define a Cedar type that includes a data type specification and a set of attributes.
+A collection of type names their definitions. These type names can be referenced in the `entityTypes` and `actions` portions of the schema wherever a type is expected.
 
-For example, consider the following example set of action entities:
+### Motivation
+
+Suppose your schema defines several entity types or action entities that share a lot of elements in common. For example, consider the following actions: both `view` and `upload` have identical `context` components.
 
 ```
 "actions": {
@@ -421,10 +441,19 @@ For example, consider the following example set of action entities:
     }
 }
 ```
-In that example, the `context` element in the `view` and `appliesTo` action is identical.
+Instead of redundantly entering common type elements separately for each action / entity type that needs them, you can define them once within `commonTypes`, and then refer to the definition in multiple places.
 
-You can use the `commonTypes` structure in a schema to define one or more blocks of reused elements. You place the `commonTypes` entry in your schema at the same level as the `entityTypes` and `actions` entries.  For example, the following example shows a block of elements called `ReusedContext`. The actions can then use any entries under `commonTypes` by reference, as shown in the following example actions.
+### Structure
+
+Each JSON object within `commonTypes` consists of the name of a type being defined and its associated definition. The definition is specified just like an [attribute type specification](#schema-attributes-specs), i.e.,
 ```
+  "TypeName": {
+    // attribute type specification
+  }
+```
+Returning to our motivating example, we can define a record type called `ReusedContext`, which is then referenced by the `view` and `upload` actions.
+```
+...
 "commonTypes": {
     "ReusedContext": {
         "type": "Record",
@@ -434,8 +463,7 @@ You can use the `commonTypes` structure in a schema to define one or more blocks
             "timestamp": { "type": "Long" }
         }
     }
-}
-
+},
 "actions": {
     "view": {
           "appliesTo": {
@@ -449,11 +477,33 @@ You can use the `commonTypes` structure in a schema to define one or more blocks
     }
 }
 ```
-For this scenario, you can test for `context.ip`, `context.is_authenticated`, and `context.timestamp` in the `when` and `unless` clauses in policies that reference the `view` and `upload` actions.
-
-As another example, consider a set of attributes that all need to be associated with a type that represents a `Person`. First, collect all of the attributes under a `Person` element in the `commonType` structure.
-
+We can also use type names defined in `commonTypes` within definitions in the `entityTypes` section. As a simple example, here we define a type `name` as a `String`, and then use the type (twice) in the `User` entity type's `attributes` specifications:
 ```
+...
+"commonTypes": {
+    "name": {
+        "type": "String",
+    }
+},
+"entityTypes": {
+    "User": {
+        "shape": {
+            "type": "Record",
+            "attributes": {
+                "firstName": {
+                    "type": "name"
+                },
+                "lastName": {
+                    "type": "name"
+                }
+            }
+        }
+    }
+}
+```
+As another example, we can use a defined record type for the `shape` of multiple entity types. In particular, we collect a set of attributes as a record named `Person` and use `Person` within the `Employee` and `Customer` entity type definitions.
+```
+...
 "commonTypes": {
     "Person": {
         "type": "Record",
@@ -462,16 +512,15 @@ As another example, consider a set of attributes that all need to be associated 
             "name": {"type": "String"}
         }
     }
-}
-```
-Then, in the `entityTypes` section, you can add each of these attributes to a new entity type by reference.
-```
+},
 "entityTypes": {
     "Employee": { "shape": { "type": "Person" } },
     "Customer": { "shape": { "type": "Person" } }
 }
 ```
 If you then send an `Employee` entity as the principal in an authorization request, you could evaluate the attributes of that principal by using syntax similar to this example: `principal.age`.
+
+Note that definitions of types appearing in `commonTypes` cannot refer to one another. For example, if both `name` and `Person` from the above example were in the same `commonTypes` section, I could not change `Person`'s define to refer to objects of type `name`.
 
 ## Example schema<a name="schema-examples"></a>
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -139,7 +139,7 @@ For more information about creating and using policy templates, see [Cedar polic
 
 A [principal](syntax-policy.md#term-parc-principal), an [action](syntax-policy.md#term-parc-action), or a [resource](syntax-policy.md#term-parc-resource) that is part of your application are all represented in Cedar as *entities*. 
 
-An entity in Cedar specifies a type, such as `User`, `Photo`, `Album`, `Group`, or `Account`. You can define whatever entity types that are required by your application scenario.
+Entities are referenced by their type and identifier, together called the entity's _unique identifier_ (UID). In the example policies P1 and P2 above, `User::"jane"`, `Action::"ViewPhoto"`, and `UserGroup::"kevinFriends"` are all UIDs. Here, `User`, `UserGroup`, and `Action` are entity types, and `"jane"`, `"kevinFriends"`, and `"viewPhoto"` are entity identifiers. The `Action` entity type is specially reserved for use with actions, but otherwise you can define whatever entity types are required by your application scenario. 
 
 Entities have attributes that describe the entity in some way. For example, an entity of type `Photo` might contain attributes like the following:
 + A `name` \(a [string](syntax-datatypes.md#datatype-string)\)
@@ -150,6 +150,33 @@ Entities have attributes that describe the entity in some way. For example, an e
 Define the attributes that are useful to your scenario.
 
 For more details about entities, see [Entity](syntax-entity.md) in [Cedar syntax - elements of the policy language](syntax.md).
+
+## Namespaces<a name="term-namespaces"></a></a>
+
+As software products increase in size and organizations grow, multiple services can be added to contribute to the overall implementation of an application or product portfolio. You can see this outcome happening when vendors offer several products to customers, or alternatively, in service meshes where multiple services contribute portions of an application.
+
+When this situation occurs, Cedar entity definitions can become ambiguous. For example, consider a vendor that offers both a hosted database product and a hosted furniture design service. In this environment, a Cedar action entity such as `Action::"createTable"` is ambiguous; it could be about creating a database table or a new piece of furniture. Similarly, an entity UID such as `Table::"0d6169ca-b246-43a7-94b9-8a68a9e8f8b3"` could refer to either product.
+
+This ambiguity can become an issue in circumstances such as the following:
+* When both services store their Cedar policies in a single policy store.
+* If policies are later aggregated into a central repository to explore cross-cutting questions about a customer’s access permissions throughout the portfolio of services.
+
+To resolve this ambiguity, you can add *namespaces* to Cedar entities, including actions. A namespace is a string prefix for a type, separated by a pair of colons \(`::`\) as a delimiter.
+
+```
+Database::Action::"createTable"
+Database::Table::"c7b981f1-97e4-436b-9af9-21054a3b30f1"
+Furniture::Action::"createTable"
+Furniture::Table::"c7b981f1-97e4-436b-9af9-21054a3b30f1"
+```
+
+Namespaces can also be nested to arbitrary depth.
+
+```
+ExampleCo::Database::Table::"c7b981f1-97e4-436b-9af9-21054a3b30f1"
+ExampleCo::Furniture::Table::"c7b981f1-97e4-436b-9af9-21054a3b30f1"
+ExampleCo::This::Is::A::Long::Name::For::Something::"12345"
+```
 
 ## Groups and hierarchies<a name="term-group"></a>
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -7,7 +7,7 @@ nav_order: 5
 # Cedar policy validation against schema<a name="validation"></a>
 {: .no_toc }
 
-As with all code, it is possible to make mistakes that result in the code not behaving as expected. For example, the following is a well-formed Cedar policy according to syntax rules, but with a number of typos and type errors. This policy assumes that there is a namespace `ExampleCo` in the schema that defines the valid principals, actions, and resources. 
+Cedar policies are code, and as with all code it is possible to make mistakes that mean the code will not behave as expected. For example, the following is a well-formed Cedar policy according to syntax rules, but with a number of typos and type errors.
 
 ```
 permit (
@@ -22,11 +22,11 @@ when {
 };
 ```
 
-Cedar can't know whether this policy is right or wrong by examining it in isolation. For example, Cedar does not know if the policy author meant Uzer or User because both are well-formed names. If the policy were subsequently evaluated during an authorization decision, Cedar would return diagnostic warnings about undefined attributes and invalid comparisons of strings and integers. But, if one weren’t looking for these diagnostics, an end-user would merely observe that the policy had no impact; it was ignored.
+Cedar can't know whether this policy is right or wrong by examining it in isolation. For example, Cedar does not know if the policy author meant `Uzer` or `User` because both are well-formed names. If the policy were subsequently evaluated during an authorization decision, it either would not match at all due to the mistakes in the policy scope (e.g., if there are no entities of type `Uzer` then the first comparison would always be false), or if the scope's errors were corrected the evaluator would return diagnostics about accessing undefined attributes and performing invalid comparisons of strings and integers. Ultimately, the policy will have no impact: policies that always evaluate to `false` or exhibit errors during evaluation are ignored.
 
-If no other policy grants access, Cedar returns a default decision of `DENY`. However, it can be frustrating when a policy isn’t behaving as expected. To avoid this frustration, it is better to learn that a policy is invalid when you're creating it, so mistakes can be fixed.
+If no policy grants access, Cedar returns a default decision of `DENY`. However, it can be frustrating when a policy isn’t behaving as expected. To avoid this frustration, it is better to learn that a policy is invalid when you're creating it, so mistakes can be fixed before they have an impact on your application's operation.
 
-This capability is provided by Cedar validation. To validate a policy, Cedar needs information about the system. It needs to know the correct names of entity types, the attributes they possess, the allowed parent/child relationships, and whether the entities can act as principals, resources, or both. All of this information is provided to Cedar by defining a [schema](terminology.md#term-schema).
+This capability is provided by Cedar **validation**. To validate a policy, Cedar needs information about the application. It needs to know the correct names of entity types, the attributes they possess, and the allowed parent/child relationships. It also needs to know which actions are allowed, and the expected types of the principal, resource, and context components that are part of requests made with this action. All of this information is provided to Cedar by defining a [**schema**](terminology.md#term-schema).
 
 This topic provides a brief overview of schemas and how they work to provide validation. For a full description of the schema format with a sample schema, see [Cedar schema format](schema.md). 
 
@@ -39,7 +39,7 @@ This topic provides a brief overview of schemas and how they work to provide val
 {:toc}
 </details>
 
-## Introduction to the schema<a name="schema-intro"></a>
+## Example of schema-based validation<a name="schema-intro"></a>
 
 The following is an example of a basic Cedar schema.
 
@@ -53,7 +53,7 @@ The following is an example of a basic Cedar schema.
                     "attributes": {
                         "name": { "type": "String" },
                         "jobLevel": { "type": "Long" },
-                        "numberOfLaptops ": {
+                        "numberOfLaptops": {
                             "type": "Long",
                             "required": false
                         }
@@ -75,9 +75,9 @@ The following is an example of a basic Cedar schema.
 This schema specifies the following:
 + The entities defined in this schema exist in the namespace `ExampleCo::Personnel`.
 + Every entity of type `Employee` in the store has an attribute `name` with a value that is a Cedar `String`, an attribute `jobLevel` with a value that is a Cedar `Long`, and an optional attribute `numberOfLaptops` that is also a Cedar `Long`.
-+ Any query that specifies action `Action::"remoteAccess"` can specify only principals that are of type `Employee`.
++ Any authorization request from the application that specifies action `Action::"remoteAccess"` is expected to specify only principals that are of type `Employee` (with no restriction on the type of a request's resource).
 
-Consider the `when` clause of the following policy.
+Consider the following policy.
 
 ```
 permit (
@@ -87,18 +87,18 @@ permit (
 )
 when {
     principal.numberOfLatpops < 5 &&        // (1)
-    principal.jobLevel > "something" &&     // (2)
+    principal.name > 3 &&                   // (2)
     principal.jobLevel == "somethingelse"   // (3)
 };
 ```
 
-Based on the previous sample schema, the Cedar validator can infer that the principal is an `Employee`; therefore, it must have a `jobLevel` attribute. With this knowledge, validation will report an error or warning on each of the comparisons 1 through 3 for the following reasons:
+The Cedar validator knows that any request that triggers evaluation of this policy must have action `Action::"remoteAccess"`. According to our example schema, such a request must have a principal of type `Employee` (the resource can be anything, or unspecified). With this knowledge, validation will report an error or warning on each of the comparisons 1 through 3 in the `when` clause for the following reasons:
 
-1. **Validation error** &ndash; The policy contains an attribute that isn’t present in the schema. In this case, the error is because of a typo (`Latpop` instead of `Laptop`).
+1. **Validation error** &ndash; The policy tries to access an attribute that isn’t defined for `Employee` types. In this case, the error is because of a typo (`numberOfLatpops` instead of `numberOfLaptops`).
 
-1. **Validation error** &ndash; The right operand of `>` is a `String`. However, `>` only accepts values of type `Long`, so this policy always raises a runtime error.
+1. **Validation error** &ndash; The left operand of `>` is of type `String`. However, `>` only accepts operands of type `Long`, so this policy always raises a runtime error.
 
-1. The left operand of `==` is always a `Long` and the right operand is always a `String`. Because the `==` operator returns false if its operands have different runtime types, this comparison always returns false. Although this comparison doesn't raise a runtime error, it probably isn’t what the policy author intended.
+1. **Validation error** &ndash; The left operand of `==` is always of type `Long` and the right operand is always a `String`. Because the `==` operator always returns false if its operands have different runtime types, this comparison always returns false. Although this comparison won't raise a runtime error during evaluation, it probably isn’t what the policy author intended and so is flagged as a validation error.
 
 ## Supported validation checks<a name="validation-supported-checks"></a>
 
@@ -109,18 +109,43 @@ The validator compares a policy with a schema to look for inconsistencies. From 
 + **Improper use of in or ==** &ndash; For example, stating `principal in Folder::"folder-name"` when a principal can't be a `File`.
 + **Unrecognized attributes** &ndash; For example, `principal.jobbLevel` has a typo and should be `jobLevel`.
 + **Unsafe access to optional attributes** &ndash; For example, `principal.numberOfLaptops` where `numberOfLaptops` is an optional attribute declared with `"required": false`. Such tests should be guarded by including a [`has`](syntax-operators.md#operator-has) check as the left side of the shortcut [&&](syntax-operators.md#operator-and) expression. For example, as in `principal has numberOfLaptops && principal.numberOfLaptops > 1`.
-+ **Type mismatch in operators** &ndash; For example, `principal.jobLevel > "14"` has an illegal comparison of a `Long` with a `String`.
-+ **Cases that always evaluate to false, and thus never apply** &ndash; For example, `when { ["hello"].contains (1) }` always evaluates to `false` so the policy can never apply.
++ **Type mismatch in operators** &ndash; For example, `principal.jobLevel > "14"` is an illegal comparison with a `String`.
++ **Cases that always evaluate to false, and thus never apply** &ndash; For example, `when { principal has manager && principal.manager == User::"Ethel" }` always evaluates to `false` when the type of `principal` will never have the `manager` attribute, as made clear in the schema, so the policy can never apply.
 
 The schema can also specify the expected format of the context record for each `Action`. Making this specification lets Cedar also flag errors on references to context.
 
-## Enforcement of validation rules<a name="validation-enforcement"></a>
+## Enforcement of validation rules: Expectations<a name="validation-enforcement"></a>
 
-When a schema is provided to Cedar, the service automatically performs validation against that schema whenever you create or edit a policy or policy template. If a newly submitted policy doesn't comply with the schema, Cedar returns an error message that contains a list of the validation failures.
+As implied by the discussion above, we expect validation to be performed _before_ a policy is used by the authorization engine to decide authorization requests. Indeed, the Cedar authorization APIs do not perform validation at the same time that a request is evaluated. Rather, validation is an entirely separate API which can be invoked when policies are loaded or created.
 
-{: .note }
->Schemas don't impact the runtime behavior of authorization for existing static policies and policy templates. Validation occurs *only* when initially creating or updating a static policy or policy template. After Verified Permissions accepts a policy, that policy continues to behave the same even if the schema changes over time. You can revalidate against an updated schema by editing the policy in some way and saving that change.   
->Validation is intended only as a debugging and diagnostic mechanism inside the administrative tools for policy creation and editing.
+We expect that **all authorization requests adhere to the rules given in the schema** used to validate the policies. In particular:
++ For a request with components _PARC_ (principal, action, resource, context), the _A_ component must be an action enumerated in the `actions` part of the schema, and the _PRC_ components will have the types given with _A_ in the schema. Our example schema above states that _A_ must always be `ExampleCo::Personnel::Action::"remoteAccess"` (since it's the only action given in the schema), and for this action _P_ must be an entity of type `ExampleCo::Personnel::Employee`, _R_ can be any entity (or omitted entirely), and _C_ must be the empty record `{}` (since no information about the context is given).
++ The entities used when evaluating the request must have the structure given in the `entityTypes` part of the schema. Our example schema above states that `ExampleCo::Personnel::Employee` entities have at least two attributes (`name` and `jobLevel`) and optionally have a third (`numberOfLaptops`), each with the types given (`String`, `Long`, and `Long`, respectively). Schemas may also specify the expected hierarhical relationships among entities (not shown in the example).
+
+If these expectations are not met then a policy that the validator accepts as valid may fail with an error when evaluated, causing it to be ignored. To see why, consider the following policy, which passes validation when using our example schema.
+```
+permit(principal, action, resource)
+when {
+    principal.name == "superuser" ||
+    principal.jobLevel > 8
+};
+```
+This policy states that any principal whose `name` is `"superuser"` or whose `jobLevel` is greater than 8 can perform any action on any resource. According to our example schema, all principals are expected to have type `Employee`, which is the only principal type given for the sole action listed.
+
+Now suppose we submitted the following authorization request:
++ _P_ = `ExampleCo::Personnel::Employee::"Rick"`
++ _A_ = `ExampleCo::Personnel::Action::"remoteAccess"`
++ _R_ = _omitted_
++ _C_ = `{}`
++ The attributes of entity `ExampleCo::Personnel::Employee::"Rick"` are the record `{ "firstName": "Rick", "jobLevel" : "admin" }`
+
+For this request the _PARC_ components conform to the schema, but the attributes of entity `ExampleCo::Personnel::Employee::"Rick"` do not: The schema prescribes that attributes `name` and `jobLevel` must be present, and the latter is mapped to value of type `Long`, but neither is true of the entity given in the request. If we evaluated the policy on this request the policy's `when`-condition expression `principal.name == "superuser"` would fail with a message like _ExampleCo::Personnel::Employee::"Rick" does not have the required attribute: name_. If we changed the entity in the request so that `firstName` was instead `name` as required by the schema, evaluation would fail on `principal.jobLevel > 8` with a message like _type error: expected long, got string_.
+
+By default, it is entirely up to the application to make sure that authorization requests are well-formed according to the schema's expectations. However, a future feature (described in [RFC 11](https://github.com/cedar-policy/rfcs/pull/11)) will allow applications to _optionally_ validate that the _PAR_ parts of a _PARC_ request adhere to the expectations given in the schema. Applications can also choose to use schema-based parsing to ensure that JSON data used to describe entities and/or a request's context _C_ match the prescriptions of the schema. If an application writer is sure that requests will always match the schema's expectations by construction, they can elect to skip these steps.
+
+You can think of a schema as a contract between the application and the policies: If the application provides requests and data that follow the prescriptions in the schema, then evaluating policies validated against that schema will surely avoid several classes of error. (The [end of this section](#validation-benefits-of-schema) discusses in detail what errors are and are not precluded by validation.)
+
+Note that this contract implies that if an application's schema changes then so has its authorization model, i.e., the actions and/or entities it may submit to the Cedar authorization engine, and their structure. Policies still in effect may need to be revalidated to make sure they are consistent with these changes.
 
 ## Namespaces<a name="validation-namespaces"></a>
 
@@ -181,9 +206,17 @@ Cedar doesn't currently require that you specify a namespace. However, if you de
 
 For more information about using a namespace as part of your schema, see [`namespace`](schema.md#schema-namespace).
 
-## Benefits of defining a schema<a name="validation-benefits-of-schema"></a>
+## Benefits of validation and schemas<a name="validation-benefits-of-schema"></a>
 
-Defining a schema is useful for purposes other than validation.
+Performing validation before using your policies gives you a significant benefit, called _validation soundness_: If your policies are deemed valid, they are sure not to exhibit most errors that could arise during request evaluation, for requests that adhere to the expectations defined by the schema. We have formally _proved_ validation soundness as part of the novel [verification guided development](https://www.amazon.science/blog/how-we-built-cedar-with-automated-reasoning-and-differential-testing) process we used to build Cedar. In particular, we implemented a version of the validator in the [Dafny verification-aware programming language](https://dafny.org), and used [automated reasoning](https://www.amazon.science/blog/a-gentle-introduction-to-automated-reasoning) to prove the validation soundness property. Then we performed extensive _differential testing_ to make sure that our Rust implementation of the validator behaves the same as the Dafny version does.
+
+Validation soundness ensures the absence of most, but not all errors that could arise during policy evaluation. The only errors that are not precluded are the following:
++ **Errors due to integer overflow**. In Cedar when you add two large `Long` numbers together the result may be too big to fit in 64 bits. Rather than wrap around (e.g., producing a negative number) as in many languages, Cedar throws an error. Validation does not currently attempt to detect this possibility, but we are developing such detection as a future feature.
++ **Errors due to missing entities**. If a policy references an entity that does not exist in the entities used to evaluate the policy, any attempt to access that entity's attributes will fail. This could happen with an entity literal (e.g., `User::"Rick".name == "rick"`) or with an entity passed in as a principal or resource (e.g., `principal.name == "rick"`, or `principal.manager.name == "Vijay"` where `principal.manager` should be an entity). Request validation ([RFC 11](https://github.com/cedar-policy/rfcs/pull/11)) and schema-based JSON parsing do not confirm the existence of entities.
+
+All other errors (as enumerated [earlier](#supported-validation-checks)) will never happen.
+
+We close by noting that defining a schema is useful for purposes other than validation.
 
 * Because a schema describes the properties of an authorization system, they can serve as an input to other tooling, such as documentation generators.
 * Use a schema to generate policy editor interfaces in situations where end-users manage fine-grained rules through point-and-click selections.

--- a/docs/what-is-cedar.md
+++ b/docs/what-is-cedar.md
@@ -13,7 +13,7 @@ Cedar is a language for writing authorization policies and making authorization 
 
 Using Cedar, you can decouple your business logic from the authorization logic. In your application's code, you preface requests made to your operations with a call to Cedar's authorization engine, asking "Is this request authorized?". Then, the application can either perform the requested operation if the decision is "allow", or return an error message if the decision is "deny".
 
-In addition to supporting the authorization requirements for your own custom applications, Cedar has been chosen as the policy language for [other authorization services](#related-services). These services take the separation of business logic and authorization logic one step further: The services host the Cedar policies, and provide APIs for managing those policies and carrying out authorization decisions on behalf of all of your applications. They handle the heavy lifting so your applications don't have to. 
+In addition to supporting the authorization requirements for your own custom applications directly, Cedar is the policy language for several [authorization services](#related-services). These services take the separation of business logic and authorization logic one step further: The services host the Cedar policies, and provide APIs for managing those policies and carrying out authorization decisions on behalf of all of your applications. They handle the heavy lifting so your applications don't have to.
 
 <details open markdown="block">
   <summary>
@@ -72,4 +72,4 @@ Cedar policies are designed to be easy to read and understand, making them acces
 
 ## Services that use Cedar<a name="related-services"></a>
 
-For a list of some of the services that use Cedar as their authorization engine, see [Cedar Integrations](https://www.cedarpolicy.com/en/integrations)
+For a list of some of the services that use Cedar as their policy language, see [Cedar Integrations](https://www.cedarpolicy.com/en/integrations)


### PR DESCRIPTION
*Description of changes:* Main change is to refactor to move introductory discussion of namespaces to from the validation section to the terminology section, but also to sprinkle some relevant text elsewhere. Some tightening and reorg of nearby text for clarity.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
