### PR TITLE
Remove space from like operator expression in syntax-operators.md

### DIFF
--- a/docs/syntax-operators.md
+++ b/docs/syntax-operators.md
@@ -76,7 +76,7 @@ Consider a query with the following context:
 ```
 In that scenario, the following expression returns `true`.
 ```
-context.location like "s 3:*"         //true
+context.location like "s3:*"         //true
 ```
 
 #### More Examples:


### PR DESCRIPTION
*Description of changes:* Remove extra space in syntax-operators.md. If I understand correctly this shouldn't work as currently documented, this expression should return `false` as there's a space in right operand.

Tested this in the playground to be sure, and it does seem to fail when the space is included as was in the previous version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
