### PR TITLE
Fix typo in description of `greaterThan()`

### DIFF
--- a/docs/collections/_policies/syntax-operators.md
+++ b/docs/collections/_policies/syntax-operators.md
@@ -322,7 +322,7 @@ false <= true          // type error
 [1, 2] <= [47, 0]      // type error
 ```
 
-### `.greaterThan()` \(decimal 'greater than or equal'\)<a name="function-greaterThan"></a>
+### `.greaterThan()` \(decimal 'greater than'\)<a name="function-greaterThan"></a>
 
 **Usage:** `<decimal>.greaterThan(<decimal>)`
 


### PR DESCRIPTION
*Description of changes:*

Fix minor typo in `greaterThan()` operator section.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
