### PR TITLE
fixed best practice examples

### DIFF
--- a/docs/collections/_bestpractices/bp-implementing-roles-attributes.md
+++ b/docs/collections/_bestpractices/bp-implementing-roles-attributes.md
@@ -8,32 +8,32 @@ has_children: false
 
 # Adding attribute-based conditions
 
-[The approach described in the previous section](best-practices/bp-implementing-roles.xml) requires that you add a new user group in your identity provider (IdP) and create a new policy for each group of resources. In the previous examples, the resource groups reflect countries: `Approver-France`, `Approver-Germany`, `Approver-UK`, and so on. There is a finite number of countries, and they don’t change very often. The company might expand into five new countries per year, and so creating new user groups in the IdP and new policies to support this expansion might not represent a significant overhead. 
+[The approach described in the previous section](best-practices/bp-implementing-roles.xml) requires that you add a new user group in your identity provider (IdP) and create a new policy for each group of resources. In the previous examples, the resource groups reflect countries: `Approver-France`, `Approver-Germany`, `Approver-UK`, and so on. There is a finite number of countries, and they don’t change very often. The company might expand into five new countries per year, and so creating new user groups in the IdP and new policies to support this expansion might not represent a significant overhead.
 
-However, consider instead a scenario where the resource groups represent projects instead of countries. Each time a project is kicked off one or more approvers must be assigned to review and approve timesheets for that project. A large global company might be starting and stopping hundreds of projects a year. With the previous approach, for every project that is kicked off a new user group representing the approver role for that project’s timesheets needs to be created in the IdP: `Approver-project03344`, `Approver-project03345`, `Approver-project03346`, and so on. This could have an impact on management of your directory, adding thousands of roles. 
+However, consider instead a scenario where the resource groups represent projects instead of countries. Each time a project is kicked off one or more approvers must be assigned to review and approve timesheets for that project. A large global company might be starting and stopping hundreds of projects a year. With the previous approach, for every project that is kicked off a new user group representing the approver role for that project’s timesheets needs to be created in the IdP: `Approver-project03344`, `Approver-project03345`, `Approver-project03346`, and so on. This could have an impact on management of your directory, adding thousands of roles.
 
 In such a scenario, you should consider whether you can use attribute-based conditions to determine which resource the role is permitted to act on. If the principal has a attribute that indicates a list of projects that the principal is assigned to and the timesheet also has a project attribute, then you can create a single policy for approvers, with an attribute condition that compares these two values, as shown in the following example.
 
-```
+```cedar
 // Role to approve timesheets for the principal's assigned projects
- permit (
-         principal in Role::"Approver",
-         action in Action::"ApproverActions",
-         resource in TimesheetGrp::"all-timesheets"
+permit (
+    principal in Role::"Approver",
+    action in Action::"ApproverActions",
+    resource in TimesheetGrp::"all-timesheets"
 ) when {
-   principal.assignedProjects.contains(resource.project)
+    principal.assignedProjects.contains(resource.project)
 };
 ```
 
 ## Assigning a role to a user
 
-An administrator can assign a user to the Approver role by adding them as a member of the group called `Role::"Approver"`. In addition, the administrator must set the value of the `assignedProjects` attribute to specify **which** projects a particular principal can approve. 
+An administrator can assign a user to the Approver role by adding them as a member of the group called `Role::"Approver"`. In addition, the administrator must set the value of the `assignedProjects` attribute to specify **which** projects a particular principal can approve.
 
-This provides an elegant solution *if* the attributes exist or can be determined in real time by the application. However, if you must extend your application to record and maintain these attributes solely for the purpose of permissions management, then you might be better off recording this information in the policy store in the form of policies. 
+This provides an elegant solution *if* the attributes exist or can be determined in real time by the application. However, if you must extend your application to record and maintain these attributes solely for the purpose of permissions management, then you might be better off recording this information in the policy store in the form of policies.
 
 ## Making an Authorization Request
 
-The application must call [`IsAuthorized`](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_IsAuthorized.html) and pass through [`entities`](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_IsAuthorized.html#verifiedpermissions-IsAuthorized-request-entities) data that describes the principal’s group memberships and the resource’s group memberships. The application must also include the value of the relevant attributes, such as the `assignedProjects` attribute on the principal and the `project` attribute on the resource. 
+The application must call [`IsAuthorized`](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_IsAuthorized.html) and pass through [`entities`](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_IsAuthorized.html#verifiedpermissions-IsAuthorized-request-entities) data that describes the principal’s group memberships and the resource’s group memberships. The application must also include the value of the relevant attributes, such as the `assignedProjects` attribute on the principal and the `project` attribute on the resource.
 
 ## Expanding to a new country
 

--- a/docs/collections/_bestpractices/bp-implementing-roles-groups.md
+++ b/docs/collections/_bestpractices/bp-implementing-roles-groups.md
@@ -41,32 +41,32 @@ permit (
 
 ## Assigning a User to a Role
 
-An administrator can assign a user to the role by adding them as a member of the associated group. For example, Bob is a member of groups `Approver-France` and `Approver-Germany`. Alice is a member of groups `Approver-France` and `Approver-UK`. 
+An administrator can assign a user to the role by adding them as a member of the associated group. For example, Bob is a member of groups `Approver-France` and `Approver-Germany`. Alice is a member of groups `Approver-France` and `Approver-UK`.
 
 The policy store isn't maintaining a record of which roles a user is assigned to, such as which groups a principal is a member of. You must keep track of this using a system separate from Cedar, such as your IdP.
 
 ## Making an Authorization Request
 
-Consider an application using Cedar policy in the Amazon Verified Permssions service. The application needs to call [`IsAuthorized`](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_IsAuthorized.html) operation, passing through [`entities`](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_IsAuthorized.html#verifiedpermissions-IsAuthorized-request-entities) data that describes the principal’s group memberships and the resource’s group memberships. 
+Consider an application using Cedar policy in the Amazon Verified Permssions service. The application needs to call [`IsAuthorized`](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_IsAuthorized.html) operation, passing through [`entities`](https://docs.aws.amazon.com/verifiedpermissions/latest/apireference/API_IsAuthorized.html#verifiedpermissions-IsAuthorized-request-entities) data that describes the principal’s group memberships and the resource’s group memberships.
 
 For example, an authorization request to determine whether Alice can approve JeanPaul’s timesheet must include the following:
 
-* The list of groups that the principal Alice is a member of. 
+* The list of groups that the principal Alice is a member of.
 * The list of groups that resource JeanPaul’s timesheet is a member of.
 
 If you are building your own authorization engine, using the Cedar SDK, then you must also pass all relevant policies, as part of the request. If you are using a hosted service, such as Amazon Verified Permissions, then the service can select the relevant policies for evaluation from its policy store.
 
 ## Expanding to a new country
 
-Adding a new country requires you to create of a new group in the IdP to represent the country specific role, and to add a new policy for that group. 
+Adding a new country requires you to create of a new group in the IdP to represent the country specific role, and to add a new policy for that group.
 
-For example, to expand into Japan, you might create a new user group called `Approver-Japan` and a new policy that references that group. This policy permits members of that group to approve only Japanese timesheets. 
+For example, to expand into Japan, you might create a new user group called `Approver-Japan` and a new policy that references that group. This policy permits members of that group to approve only Japanese timesheets.
 
-```
-# Role policy to approve Japanese timesheets
+```cedar
+// Role policy to approve Japanese timesheets
 permit (
-         principal in Role::"Approver-Japan",
-         action in Action::"ApproverActions",
-         resource in TimesheetGrp::"Japanese-timesheets"
+    principal in Role::"Approver-Japan",
+    action in Action::"ApproverActions",
+    resource in TimesheetGrp::"Japanese-timesheets"
 );
 ```

--- a/docs/collections/_bestpractices/bp-implementing-roles-templates.md
+++ b/docs/collections/_bestpractices/bp-implementing-roles-templates.md
@@ -10,15 +10,15 @@ has_children: false
 
 The recommended approach to implementing role-based access control in Cedar is to use principal groups to represent the roles. However, this requires a system of record, such as an identity provider (IdP), to keep track of which users are assigned to which roles. If this isn't an option, then you can manage role assignment within your policy store by using policy templates.
 
-Using this approach, you create a template for each of the roles. So, continuing with the timesheet example from the previous sections, you create a Worker template and an Approver template. 
+Using this approach, you create a template for each of the roles. So, continuing with the timesheet example from the previous sections, you create a Worker template and an Approver template.
 
-```
-# Approver-Role-Assignment policy template 
+```cedar
+// Approver-Role-Assignment policy template 
 permit ( 
     principal == ?principal, 
     action in Action::"ApproverActions", 
     resource in ?resource 
-)
+);
 ```
 
 ## Assigning a role to a user
@@ -43,11 +43,9 @@ createPolicy (
 
 You can see that each template-linked policy grants permissions to a specified user to perform the actions in the template on the specified resources in the resource group.
 
-
 ## Making an authorization request
 
 The entity data within the authorization request must include the group membership of the resource. However, this approach doesn’t need to include group memberships of the principal, because we created a separate template-linked policy for each assigned principal.
-
 
 ## Expanding to a new country
 
@@ -55,6 +53,6 @@ To create an approver role for a new country, it's not necessary to add a new us
 
 ## Considerations when using templates
 
-If you use the template approach, you tightly couple the policy store to the life-cycle management of your users. When you onboard a new user and assign them to a role, you must create template-linked policies for them. When that user changes roles, you must find those policies, archive them, and then create new template-linked policies. When the user leaves the organization, you must archive the policies for that user. If you delete the policies instead of archiving them, then you lose the historical record of who was permitted to do what, which might be required for forensics purposes. 
+If you use the template approach, you tightly couple the policy store to the life-cycle management of your users. When you onboard a new user and assign them to a role, you must create template-linked policies for them. When that user changes roles, you must find those policies, archive them, and then create new template-linked policies. When the user leaves the organization, you must archive the policies for that user. If you delete the policies instead of archiving them, then you lose the historical record of who was permitted to do what, which might be required for forensics purposes.
 
 These challenges reinforce each other if the role is a complex set of permissions requiring multiple policies. In the simple example above, the permissions for the role can be expressed as a single policy statement. Therefore, assigning a principal requires the creation of a single template-linked policy. However, more complex roles might require several policies to express the permissions. In that case, the assignment and unassignment processes can become more burdensome, as you must create or delete multiple template-linked policies.

--- a/docs/collections/_bestpractices/bp-implementing-roles.md
+++ b/docs/collections/_bestpractices/bp-implementing-roles.md
@@ -13,7 +13,7 @@ This topic helps you to understand how to implement role-based access control (R
 
 ## What is a role?
 
-We can define a *role* as a set of tasks that you assign to a person or thing (the principal) for a specific purpose. To perform those tasks, the principal needs permissions to perform the appropriate operations on the relevant resources. You express those permissions as Cedar policies. 
+We can define a *role* as a set of tasks that you assign to a person or thing (the principal) for a specific purpose. To perform those tasks, the principal needs permissions to perform the appropriate operations on the relevant resources. You express those permissions as Cedar policies.
 
 * Roles are defined independently of the principals to which they are assigned.
 * A principal can be assigned to many roles, or none at all.
@@ -40,7 +40,7 @@ permit (
 
 Note that we’ve also created a resource group called  `TimesheetGrp::"all-timesheets"`  As the name suggests, all timesheets are members of this resource group.
 
-We can simplify this policy a little bit, by creating an Action group. In this case we’d create an action group called `ApproverActions` , with the members `Action::"TimeSheetReview"`  and  `Action::"TimeSheetApprove"`.   
+We can simplify this policy a little bit, by creating an Action group. In this case we’d create an action group called `ApproverActions` , with the members `Action::"TimeSheetReview"`  and  `Action::"TimeSheetApprove"`.
 
 We can now rewrite the policy as the following:
 
@@ -52,12 +52,13 @@ permit (
     resource in TimesheetGrp::"all-timesheets"
 );
 ```
+
 Action groups can be defined in your schema, so your application doesn’t need to pass action group memberships as part of the entity data of an authorization request. A benefit of Action groups is that you can now add another action to the Approver role by simply adding the new action to the definition of `Action::"ApproverActions"` in the schema. You do ***not*** have to update any of your policies.  
-If we want to assign Joe to the role of Approver, we add him as a member of the group called `Role::"Approver"`.  That information needs to be tracked outside of the policy store, potentially in the IdP, or some other system of record. Assigning and unassigning principals to a role doesn’t require us to modify any policies. 
+If we want to assign Joe to the role of Approver, we add him as a member of the group called `Role::"Approver"`.  That information needs to be tracked outside of the policy store, potentially in the IdP, or some other system of record. Assigning and unassigning principals to a role doesn’t require us to modify any policies.
 
 When making an authorization request, we need to provide information about which groups the principal is in. For example, when asking whether `User::"Joe"` is permitted to take the action `TimeSheetReview`, we need to provide the authorization engine with the information that Joe is a member of the group `Role::"Approver"`.  
 
-## Managing resource specific roles 
+## Managing resource specific roles
 
 So far, we’ve kept things very simple. A principal assigned to the Approver role can approve all timesheets. Things get more complicated when a role must be assigned for a specific subset of resources. For example, the timesheet-approver could be country specific. Bob might be authorized to approve timesheets in Germany and France, while Alice can approve timesheets in France and the UK.  
 

--- a/docs/collections/_bestpractices/bp-meta-permissions.md
+++ b/docs/collections/_bestpractices/bp-meta-permissions.md
@@ -13,9 +13,9 @@ One simple approach to meta-permissions is to introduce a new action, such as `e
 
 ```cedar
 permit (
-  principal == User::"&ExampleToken1;",
-  action == Action::"editPermissions",
-  resource in Account::"&ExampleToken2;"
+    principal == User::"&ExampleToken1;",
+    action == Action::"editPermissions",
+    resource in Account::"&ExampleToken2;"
 );
 ```
 
@@ -25,12 +25,12 @@ Richer implementations may choose more granular meta-permissions, such as `editR
 
 ```cedar
 permit (
-  principal,
-  action == Action::"editPermissions",
-  resource
+    principal,
+    action == Action::"editPermissions",
+    resource
 )
 when {
-  principal == resource.owner
+    principal == resource.owner
 };
 ```
 

--- a/docs/collections/_bestpractices/bp-mutable-identifiers.md
+++ b/docs/collections/_bestpractices/bp-mutable-identifiers.md
@@ -11,9 +11,9 @@ Mutable identifiers can't be used in policy statements. An example of a mutable 
 
 ```cedar
 permit (
-  principal in Group::"TeamExample",
-  action in ...,
-  resource in ...
+    principal in Group::"TeamExample",
+    action in ...,
+    resource in ...
 );
 ```
 
@@ -23,8 +23,8 @@ For these reasons, policies must refer to only unique, normalized, immutable, an
 
 ```cedar
 permit (
-  principal in Group::"fcaf664d4f89fec0cda8", // "TeamExample"
-  action in ...,
-  resource in ...
+    principal in Group::"fcaf664d4f89fec0cda8", // "TeamExample"
+    action in ...,
+    resource in ...
 );
 ```

--- a/docs/collections/_bestpractices/bp-normalize-data-input.md
+++ b/docs/collections/_bestpractices/bp-normalize-data-input.md
@@ -45,8 +45,8 @@ Note the capitalization of `EXAMPLE.COM` and multiple `/` characters at the begi
 ```cedar
 permit (principal, action, resource)
 when {
-  context.url.host == "example.com" && // Won't match "EXAMPLE.COM"
-  context.url.path == "/path/to/page"  // Won't match "///path/to/page"
+    context.url.host == "example.com" && // Won't match "EXAMPLE.COM"
+    context.url.path == "/path/to/page"  // Won't match "///path/to/page"
 };
 ```
 
@@ -65,9 +65,9 @@ If a service accepts all formats of the identifier, which format can be reliably
 // This policy won't match if the Object ID is provided in a different format.
 // This allows the caller to bypass the forbid rule and retrieve the object.
 forbid (
-  principal,
-  action == Action::"getObject",
-  resource == Object::"a9edd19b-46f3-486b-887d-4c378aced880"
+    principal,
+    action == Action::"getObject",
+    resource == Object::"a9edd19b-46f3-486b-887d-4c378aced880"
 );
 ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

minor fixes in Best Practice examples
- fixed mismatching indentation, added missing cedar code block, and fixed `#` uses as comment
- removed various trailing spaces in markdown text

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
