### PR TITLE
small bug: record --> array

### DIFF
--- a/docs/collections/_auth/entities-syntax.md
+++ b/docs/collections/_auth/entities-syntax.md
@@ -32,7 +32,7 @@ At the top level, Cedar expects a JSON list (an array using `[ ]`) of objects. E
 [
     {
         "uid": {},
-        "parents": {},
+        "parents": [],
         "attrs": {}
     },
     {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The `parents` attribute of an entity is an array, not a record.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
