### PR TITLE
Fix some inaccuracies in the JSON schema grammar

### DIFF
--- a/docs/collections/_schema/schema-grammar.md
+++ b/docs/collections/_schema/schema-grammar.md
@@ -55,7 +55,7 @@ NameSpace ::= STR ('::' STR)*
 The `EntityTypes` element is identified by the keyword `entityTypes` followed by a comma-separated list of Entity types supported by your application. For more information see [`entityTypes`](../schema/schema.html#schema-entityTypes).
 
 ```
-EntityTypes ::= 'entityTypes' ':' '{' ( EntityType ( ',' EntityType )* )? '}'
+EntityTypes ::= 'entityTypes' ':' '[' ( EntityType ( ',' EntityType )* )? ']'
 ```
 
 ## `EntityType` {#grammar-schema-EntityType}
@@ -71,7 +71,7 @@ EntityType ::= IDENT ':' '{' ( 'memberOfTypes' ':' '[' (IDENT ( ',' IDENT )*)? '
 The `Actions` element is a list of the individual actions supported by your application.
 
 ```
-Actions ::= '"actions"' ':' '{' ( Action ( ',' Action )* )? '}'
+Actions ::= '"actions"' ':' '[' ( Action ( ',' Action )* )? ']'
 ```
 
 ## `Action` {#grammar-schema-Action}
@@ -81,7 +81,7 @@ The `memberOf` element specifies what action groups the declared action is a mem
 The `appliesTo` element defines the principal types, resource types, and other context information that can be specified in a request for the action.
 
 ```
-Action : STR ':' '{' ( '"memberOf"' ':' '[' ( STR ( ',' STR )* )? ']' )? ',' ( '"appliesTo" ':' {' PrincipalTypes? ',' ResourceTypes? ',' Context? '}' )? '}'
+Action : STR ':' '{' ( '"memberOf"' ':' '[' ( STR ( ',' STR )* )? ']' )? ',' ( '"appliesTo"' ':' '{' PrincipalTypes? ',' ResourceTypes? ',' Context? '}' )? '}'
 ```
 
 ## `PrincipalTypes` {#grammar-schema-PrincipalTypes}
@@ -105,7 +105,7 @@ ResourceTypes ::= '"resourceTypes"': '[' ( IDENT ( ',' IDENT )* )? ']'
 The `Context` element describes the type of the context record for an action using the same `TypeJson` format used for the shape of an entity type.
 
 ```
-Context ::= '"context"': TypeJson
+Context ::= '"context"' ':' TypeJson
 ```
 
 ## `TypeJson` {#grammar-schema-TypeJson}

--- a/docs/collections/_schema/schema-grammar.md
+++ b/docs/collections/_schema/schema-grammar.md
@@ -86,7 +86,7 @@ Action : STR ':' '{' ( '"memberOf"' ':' '[' ( STR ( ',' STR )* )? ']' )? ',' ( '
 
 ## `PrincipalTypes` {#grammar-schema-PrincipalTypes}
 
-The `PrincipalTypes` element is identified by the keyword `principalType` followed by a comma-separated array list of the principal types supported by your application.
+The `PrincipalTypes` element is identified by the keyword `principalType` followed by a comma-separated array list of the principal types supported by your application for the containing action.
 
 ```
 PrincipalTypes ::= '"principalTypes"': '[' ( IDENT ( ',' IDENT )* )? ']'
@@ -94,10 +94,18 @@ PrincipalTypes ::= '"principalTypes"': '[' ( IDENT ( ',' IDENT )* )? ']'
 
 ## `ResourceTypes` {#grammar-schema-ResourceTypes}
 
-The `ResourceTypes` element describes
+The `ResourceTypes` element follows the same format and serves the same purpose as as the `PrincipalTypes`, but instead lists the resource types supported for the containing action.
 
 ```
 ResourceTypes ::= '"resourceTypes"': '[' ( IDENT ( ',' IDENT )* )? ']'
+```
+
+## `Context` {#grammar-schema-Context}
+
+The `Context` element describes the type of the context record for an action using the same `TypeJson` format used for the shape of an entity type.
+
+```
+Context ::= '"context"': TypeJson
 ```
 
 ## `TypeJson` {#grammar-schema-TypeJson}

--- a/docs/collections/_schema/schema-grammar.md
+++ b/docs/collections/_schema/schema-grammar.md
@@ -35,9 +35,11 @@ The grammar ignores whitespace and comments.
 ## `Schema` {#grammar-schema}
 
 A schema consists of a [`NameSpace`](#grammar-schema-NameSpace) JSON object that contains a list of [`EntityTypes`](#grammar-schema-EntityTypes), and a list of [`Actions`](#grammar-schema-Actions).
+The grammar assumes a particular order of keys in JSON objects to simplify the presentation, but this order is not technically required.
+For example, the grammar as written requires that entity type declarations appear before actions, but actions may nonetheless be declared before entity types.
 
 ```
-Schema ::= '{' NameSpace ':' '{' EntityTypes ',' Actions [(',' commonTypes )] '}' '}'
+Schema ::= '{' NameSpace ':' '{' EntityTypes ',' Actions (',' commonTypes )? '}' '}'
 ```
 
 ## `NameSpace` {#grammar-schema-NameSpace}
@@ -50,10 +52,10 @@ NameSpace ::= STR ('::' STR)*
 
 ## `EntityTypes` {#grammar-schema-EntityTypes}
 
-The `EntityTypes` element is identified by the keyword `entityTypes` followed by a comma-separated list of one or more Entity types supported by your application. For more information see [`entityTypes`](../schema/schema.html#schema-entityTypes).
+The `EntityTypes` element is identified by the keyword `entityTypes` followed by a comma-separated list of Entity types supported by your application. For more information see [`entityTypes`](../schema/schema.html#schema-entityTypes).
 
 ```
-EntityTypes ::= 'entityTypes: {' EntityType ( ',' EntityType )* '}'
+EntityTypes ::= 'entityTypes' ':' '{' ( EntityType ( ',' EntityType )* )? '}'
 ```
 
 ## `EntityType` {#grammar-schema-EntityType}
@@ -61,7 +63,7 @@ EntityTypes ::= 'entityTypes: {' EntityType ( ',' EntityType )* '}'
 An `EntityType` element describes one entity type supported by your application. It begins with a name string for the entity type that, when qualified by its parent [namespace](#grammar-schema-NameSpace), uniquely identifies this entity type. This element contains a `memberOfTypes` element that is an array list of any parent entity types that entities of this type can be a member or child of in a hierarchy. It also contains a `shape` element that describes how entities of this type are constructed.
 
 ```
-EntityType ::= IDENT ':' '{' 'memberOfTypes' ':' '[' (EntityType ( ',' EntityType )*)? '],' 'shape': TypeJson '}'
+EntityType ::= IDENT ':' '{' ( 'memberOfTypes' ':' '[' (IDENT ( ',' IDENT )*)? ']' )? ',' ( 'shape': TypeJson )? '}'
 ```
 
 ## `Actions` {#grammar-schema-Actions}
@@ -69,15 +71,17 @@ EntityType ::= IDENT ':' '{' 'memberOfTypes' ':' '[' (EntityType ( ',' EntityTyp
 The `Actions` element is a list of the individual actions supported by your application.
 
 ```
-Actions ::= '"actions"' ':' Action*
+Actions ::= '"actions"' ':' '{' ( Action ( ',' Action )* )? '}'
 ```
 
 ## `Action` {#grammar-schema-Action}
 
-The `Action` element describes one action supported by your application. An action begins with a name string, and includes an `appliesTo` element. The `appliesTo` element defines the principal types, resource types, and other context information that can be specified in a request for the action.
+The `Action` element describes one action supported by your application. An action begins with a name string, and may include a `memberOf` and `appliesTo` element.
+The `memberOf` element specifies what action groups the declared action is a member of in the action hierarchy.
+The `appliesTo` element defines the principal types, resource types, and other context information that can be specified in a request for the action.
 
 ```
-Action : STR ':' '{' '"appliesTo": {' PrincipalTypes? ResourceTypes? Context? '}'
+Action : STR ':' '{' ( '"memberOf"' ':' '[' ( STR ( ',' STR )* )? ']' )? ',' ( '"appliesTo" ':' {' PrincipalTypes? ',' ResourceTypes? ',' Context? '}' )? '}'
 ```
 
 ## `PrincipalTypes` {#grammar-schema-PrincipalTypes}
@@ -85,7 +89,7 @@ Action : STR ':' '{' '"appliesTo": {' PrincipalTypes? ResourceTypes? Context? '}
 The `PrincipalTypes` element is identified by the keyword `principalType` followed by a comma-separated array list of the principal types supported by your application.
 
 ```
-PrincipalTypes ::= '"principalTypes"': '[' IDENT* ']'
+PrincipalTypes ::= '"principalTypes"': '[' ( IDENT ( ',' IDENT )* )? ']'
 ```
 
 ## `ResourceTypes` {#grammar-schema-ResourceTypes}
@@ -93,7 +97,7 @@ PrincipalTypes ::= '"principalTypes"': '[' IDENT* ']'
 The `ResourceTypes` element describes
 
 ```
-ResourceTypes ::= '"resourceTypes"': '[' IDENT* ']'
+ResourceTypes ::= '"resourceTypes"': '[' ( IDENT ( ',' IDENT )* )? ']'
 ```
 
 ## `TypeJson` {#grammar-schema-TypeJson}

--- a/docs/collections/_schema/schema-grammar.md
+++ b/docs/collections/_schema/schema-grammar.md
@@ -39,7 +39,7 @@ The grammar assumes a particular order of keys in JSON objects to simplify the p
 For example, the grammar as written requires that entity type declarations appear before actions, but actions may nonetheless be declared before entity types.
 
 ```
-Schema ::= '{' NameSpace ':' '{' EntityTypes ',' Actions (',' commonTypes )? '}' '}'
+Schema ::= '{' NameSpace ':' '{' EntityTypes ',' Actions [',' CommonTypes] '}' '}'
 ```
 
 ## `NameSpace` {#grammar-schema-NameSpace}
@@ -47,7 +47,7 @@ Schema ::= '{' NameSpace ':' '{' EntityTypes ',' Actions (',' commonTypes )? '}'
 The `NameSpace` element is a string made up of a sequence of one or more substrings separated by double colons (`::`). This namespace serves as a qualifier, or disambiguator, for entity types that might be defined in multiple namespaces. The type reference must include the namespace so that Cedar uses the correct entity type. For more information see [`namespace`](../schema/schema.html#schema-namepace).
 
 ```
-NameSpace ::= STR ('::' STR)*
+NameSpace ::= '"' STR { '::' STR } '"'
 ```
 
 ## `EntityTypes` {#grammar-schema-EntityTypes}
@@ -55,7 +55,7 @@ NameSpace ::= STR ('::' STR)*
 The `EntityTypes` element is identified by the keyword `entityTypes` followed by a comma-separated list of Entity types supported by your application. For more information see [`entityTypes`](../schema/schema.html#schema-entityTypes).
 
 ```
-EntityTypes ::= 'entityTypes' ':' '[' ( EntityType ( ',' EntityType )* )? ']'
+EntityTypes ::= 'entityTypes' ':' '[' [ EntityType { ',' EntityType } ] ']'
 ```
 
 ## `EntityType` {#grammar-schema-EntityType}
@@ -63,7 +63,7 @@ EntityTypes ::= 'entityTypes' ':' '[' ( EntityType ( ',' EntityType )* )? ']'
 An `EntityType` element describes one entity type supported by your application. It begins with a name string for the entity type that, when qualified by its parent [namespace](#grammar-schema-NameSpace), uniquely identifies this entity type. This element contains a `memberOfTypes` element that is an array list of any parent entity types that entities of this type can be a member or child of in a hierarchy. It also contains a `shape` element that describes how entities of this type are constructed.
 
 ```
-EntityType ::= IDENT ':' '{' ( 'memberOfTypes' ':' '[' (IDENT ( ',' IDENT )*)? ']' )? ',' ( 'shape': TypeJson )? '}'
+EntityType ::= IDENT ':' '{' [ 'memberOfTypes' ':' '[' [ IDENT { ',' IDENT } ] ']' ] ',' [ 'shape': TypeJson ] '}'
 ```
 
 ## `Actions` {#grammar-schema-Actions}
@@ -71,7 +71,7 @@ EntityType ::= IDENT ':' '{' ( 'memberOfTypes' ':' '[' (IDENT ( ',' IDENT )*)? '
 The `Actions` element is a list of the individual actions supported by your application.
 
 ```
-Actions ::= '"actions"' ':' '[' ( Action ( ',' Action )* )? ']'
+Actions ::= '"actions"' ':' '[' [ Action { ',' Action } ] ']'
 ```
 
 ## `Action` {#grammar-schema-Action}
@@ -81,7 +81,7 @@ The `memberOf` element specifies what action groups the declared action is a mem
 The `appliesTo` element defines the principal types, resource types, and other context information that can be specified in a request for the action.
 
 ```
-Action : STR ':' '{' ( '"memberOf"' ':' '[' ( STR ( ',' STR )* )? ']' )? ',' ( '"appliesTo"' ':' '{' PrincipalTypes? ',' ResourceTypes? ',' Context? '}' )? '}'
+Action ::= STR ':' '{' [ '"memberOf"' ':' '[' [ STR { ',' STR } ] ']' ] ',' [ '"appliesTo"' ':' '{' [PrincipalTypes] ',' [ResourceTypes] ',' [Context] '}' ] '}'
 ```
 
 ## `PrincipalTypes` {#grammar-schema-PrincipalTypes}
@@ -89,7 +89,7 @@ Action : STR ':' '{' ( '"memberOf"' ':' '[' ( STR ( ',' STR )* )? ']' )? ',' ( '
 The `PrincipalTypes` element is identified by the keyword `principalType` followed by a comma-separated array list of the principal types supported by your application for the containing action.
 
 ```
-PrincipalTypes ::= '"principalTypes"': '[' ( IDENT ( ',' IDENT )* )? ']'
+PrincipalTypes ::= '"principalTypes"': '[' [ IDENT { ',' IDENT } ] ']'
 ```
 
 ## `ResourceTypes` {#grammar-schema-ResourceTypes}
@@ -97,7 +97,7 @@ PrincipalTypes ::= '"principalTypes"': '[' ( IDENT ( ',' IDENT )* )? ']'
 The `ResourceTypes` element follows the same format and serves the same purpose as as the `PrincipalTypes`, but instead lists the resource types supported for the containing action.
 
 ```
-ResourceTypes ::= '"resourceTypes"': '[' ( IDENT ( ',' IDENT )* )? ']'
+ResourceTypes ::= '"resourceTypes"': '[' [ IDENT { ',' IDENT } ] ']'
 ```
 
 ## `Context` {#grammar-schema-Context}
@@ -153,7 +153,7 @@ EntityRef ::= '"type": "Entity", "name": "' Name '"'
 The `Record` element describes
 
 ```
-Record ::= '"type": "Record", "attributes": {' ( RecordAttr (',' RecordAttr )* )? '}'
+Record ::= '"type": "Record", "attributes": {' [ RecordAttr { ',' RecordAttr } ] '}'
 ```
 
 ## `RecordAttr` {#grammar-schema-RecordAttr}
@@ -161,20 +161,16 @@ Record ::= '"type": "Record", "attributes": {' ( RecordAttr (',' RecordAttr )* )
 The `RecordAttr` element describes
 
 ```
-RecordAttr ::= STR ': {' Type (', "required": ' ( true | false ))? '}'
+RecordAttr ::= STR ': {' Type [',' '"required"' ':' ( true | false )] '}'
 ```
 
 ## `STR` {#grammar-schema-STR}
-
-The `STR` element describes
 
 ```
 STR ::= Fully-escaped Unicode surrounded by '"'s
 ```
 
 ## `IDENT` {#grammar-IDENT}
-
-The `IDENT` element describes
 
 ```
 IDENT ::= ['_''a'-'z''A'-'Z']['_''a'-'z''A'-'Z''0'-'9']* - RESERVED


### PR DESCRIPTION
* Add note the order of fields as written in grammar is not required
* Make grammar notation more consistent in some places
* A schema may declare zero entity types 
* `memberOfTypes` and `shape` are optional in an entity type declaration
* action declaration grammar did not mention `memberOf` (fix #46).
* Grammar production for `Context` was not defined (fix #47).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
