### PR TITLE
Update broken link for the is operator in doc history

### DIFF
--- a/docs/collections/_other/doc-history.md
+++ b/docs/collections/_other/doc-history.md
@@ -12,7 +12,7 @@ The following table describes major documentation updates for Cedar.
 
 | Description | Date |
 | --- | --- |
-| Added [`is` operator](../auth/syntax-operators.html) | December 15, 2023 |
+| Added [`is` operator](../policies/syntax-operators.html) | December 15, 2023 |
 | Added [Entities & context syntax](../auth/entities-syntax.html) topic | July 27, 2023 |
 | Added [Schema grammar](../schema/schema-grammar.html) topic | July 17, 2023 |
 | Added [JSON policy format](../policies/json-format.html) reference page | July 14, 2023 |


### PR DESCRIPTION
## What
Update the broken link for the`is` operator in doc history.

## Why
Because it's broken `https://docs.cedarpolicy.com/auth/syntax-operators.html` 

<img width="1436" alt="Screenshot 2023-12-21 at 12 27 30" src="https://github.com/cedar-policy/cedar-docs/assets/8863200/09e76dfe-096e-4b04-b4e1-442246d3700c">

## How
Just replaced it with the proper one.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
