### PR TITLE
Fix link in Adding attribute-based conditions doc

### DIFF
--- a/docs/collections/_bestpractices/bp-implementing-roles-attributes.md
+++ b/docs/collections/_bestpractices/bp-implementing-roles-attributes.md
@@ -8,7 +8,7 @@ has_children: false
 
 # Adding attribute-based conditions
 
-[The approach described in the previous section](best-practices/bp-implementing-roles.xml) requires that you add a new user group in your identity provider (IdP) and create a new policy for each group of resources. In the previous examples, the resource groups reflect countries: `Approver-France`, `Approver-Germany`, `Approver-UK`, and so on. There is a finite number of countries, and they don’t change very often. The company might expand into five new countries per year, and so creating new user groups in the IdP and new policies to support this expansion might not represent a significant overhead.
+[The approach described in the previous section](best-practices/bp-implementing-roles-groups.html) requires that you add a new user group in your identity provider (IdP) and create a new policy for each group of resources. In the previous examples, the resource groups reflect countries: `Approver-France`, `Approver-Germany`, `Approver-UK`, and so on. There is a finite number of countries, and they don’t change very often. The company might expand into five new countries per year, and so creating new user groups in the IdP and new policies to support this expansion might not represent a significant overhead.
 
 However, consider instead a scenario where the resource groups represent projects instead of countries. Each time a project is kicked off one or more approvers must be assigned to review and approve timesheets for that project. A large global company might be starting and stopping hundreds of projects a year. With the previous approach, for every project that is kicked off a new user group representing the approver role for that project’s timesheets needs to be created in the IdP: `Approver-project03344`, `Approver-project03345`, `Approver-project03346`, and so on. This could have an impact on management of your directory, adding thousands of roles.
 
@@ -29,7 +29,7 @@ permit (
 
 An administrator can assign a user to the Approver role by adding them as a member of the group called `Role::"Approver"`. In addition, the administrator must set the value of the `assignedProjects` attribute to specify **which** projects a particular principal can approve.
 
-This provides an elegant solution *if* the attributes exist or can be determined in real time by the application. However, if you must extend your application to record and maintain these attributes solely for the purpose of permissions management, then you might be better off recording this information in the policy store in the form of policies.
+This provides an elegant solution _if_ the attributes exist or can be determined in real time by the application. However, if you must extend your application to record and maintain these attributes solely for the purpose of permissions management, then you might be better off recording this information in the policy store in the form of policies.
 
 ## Making an Authorization Request
 


### PR DESCRIPTION
## What
Update the broken link for Adding attribute-based conditions doc

## Why
Because it's broken. Should be https://docs.cedarpolicy.com/bestpractices/bp-implementing-roles-groups.html, instead of https://docs.cedarpolicy.com/bestpractices/best-practices/bp-implementing-roles.xml. 

<img width="1438" alt="Screenshot 2023-12-28 at 18 44 17" src="https://github.com/cedar-policy/cedar-docs/assets/8863200/127d242b-e484-473a-8120-9ba4854db8e6">


## How
Just replaced it with the proper one.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
