### PR TITLE
update schema terminology: 'human-readable' -> 'Cedar'

### DIFF
--- a/docs/collections/_other/doc-history.md
+++ b/docs/collections/_other/doc-history.md
@@ -17,7 +17,7 @@ The following table tracks changes to the Cedar language version. The language v
 | 3.4 | JSON format for policy sets [cedar#549](https://github.com/cedar-policy/cedar/issues/549) | 3.3.0-3.4.0 | August 19, 2024 |
 | 3.3 | References between common types [cedar#154](https://github.com/cedar-policy/cedar/issues/154) | 3.2.0 - 3.2.4 | May 17, 2024 |
 | 3.2 | General multiplication operator [rfc#57](https://github.com/cedar-policy/rfcs/blob/main/text/0057-general-multiplication.md) | 3.1.2 - 3.1.4 | March 29, 2024 |
-| 3.1 | Human-readable schema syntax [rfc#24](https://github.com/cedar-policy/rfcs/blob/main/text/0024-schema-syntax.md) | 3.1.0 - 3.1.1 | March 8, 2024 |
+| 3.1 | Cedar schema format [rfc#24](https://github.com/cedar-policy/rfcs/blob/main/text/0024-schema-syntax.md) | 3.1.0 - 3.1.1 | March 8, 2024 |
 | 3.0 | `is` operator [rfc#5](https://github.com/cedar-policy/rfcs/blob/main/text/0005-is-operator.md)<br/>Stricter validation [rfc#19](https://github.com/cedar-policy/rfcs/blob/main/text/0019-stricter-validation.md)<br/>Disallow duplicate keys in records [rfc#20](https://github.com/cedar-policy/rfcs/blob/main/text/0020-unique-record-keys.md)<br/>Request validation [cedar#191](https://github.com/cedar-policy/cedar/issues/191)<br/>Entity validation [cedar#360](https://github.com/cedar-policy/cedar/pull/360) | 3.0.0 - 3.0.1 | December 15, 2023 |
 | 2.2 | General multiplication operator (backport to 2.x) [rfc#57](https://github.com/cedar-policy/rfcs/blob/main/text/0057-general-multiplication.md) | 2.4.5 - 2.5.0 | April 1, 2024 |
 | 2.1 | Disallow whitespace in namespaces [rfc#9](https://github.com/cedar-policy/rfcs/blob/main/text/0009-disallow-whitespace-in-entityuid.md) | 2.3.0 - 2.4.4 | June 29, 2023 |
@@ -29,7 +29,7 @@ The following table describes major documentation updates for Cedar.
 | Description | Date |
 | --- | --- |
 | Added [JSON policy set format](../policies/json-format.html#policy-set-format) sub-topic | August 19, 2024 |
-| Added [Human-readable schema format](../schema/human-readable-schema.html) topic | February 21, 2024 |
+| Added [Cedar schema format](../schema/human-readable-schema.html) topic | February 21, 2024 |
 | Added [`is` operator](../policies/syntax-operators.html#operator-is) sub-topic | December 15, 2023 |
 | Added [Entities & context syntax](../auth/entities-syntax.html) topic | July 27, 2023 |
 | Added [Schema grammar](../schema/schema-grammar.html) topic | July 17, 2023 |

--- a/docs/collections/_schema/human-readable-schema-grammar.md
+++ b/docs/collections/_schema/human-readable-schema-grammar.md
@@ -1,14 +1,14 @@
 ---
 layout: default
-title: Human-readable schema grammar
+title: Cedar schema grammar
 nav_order: 2
 ---
 <!-- markdownlint-disable-file MD040 -->
 
-# Grammar specification for human-readable schemas {#schema-grammar}
+# Grammar specification for Cedar schemas {#schema-grammar}
 {: .no_toc }
 
-This topic describes the grammar specification for the human-readable schema format. For a more complete description, see [Schema format](../schema/human-readable-schema.html).
+This topic describes the grammar specification for the Cedar schema format. For a more complete description, see [Cedar schema format](../schema/human-readable-schema.html).
 
 The grammar applies the following conventions. 
 + Words with initial capital letters designate grammar constructs.

--- a/docs/collections/_schema/human-readable-schema.md
+++ b/docs/collections/_schema/human-readable-schema.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Human-readable schema format
+title: Cedar schema format
 nav_order: 2
 ---
 
-# Human-readable schema format {#schema}
+# Cedar schema format {#schema}
 {: .no_toc }
 
 <details open markdown="block">
@@ -16,11 +16,11 @@ nav_order: 2
 {:toc}
 </details>
 
-This topic describes Cedar's human-readable schema format.
+This topic describes the Cedar schema format.
 
 ## Schema format {#schema-format}
 
-A schema consists of zero or more namespaces, each of which contains declarations of three types --- *Entity Type Declaration*, *Action Declaration*, and *Common Type Declaration*. These declarations define entity types and actions, and common types that define types that can be referenced by the Entity Type and Action Declarations. Declarations are delimited by `;` characters. Note that in the human-readable schema format, unlike in the JSON schema format, you can write Cedar-style comments.
+A schema consists of zero or more namespaces, each of which contains declarations of three types --- *Entity Type Declaration*, *Action Declaration*, and *Common Type Declaration*. These declarations define entity types and actions, and common types that define types that can be referenced by the Entity Type and Action Declarations. Declarations are delimited by `;` characters. Note that in the Cedar schema format, unlike in the JSON schema format, you can write Cedar-style comments.
 
 ## Namespace {#schema-namespace}
 
@@ -48,7 +48,7 @@ entity User in [Group] {
 };
 ```
 
-Note that in the human-readable schema format, unlike in the JSON schema format, you can declare multiple entity types that share the same definition using a single declaration. For example, `entity UserA, UserB, UserC` declares entity types `UserA`, `UserB`, and `UserC` that all have the same membership relations and shapes.
+Note that in the Cedar schema format, unlike in the JSON schema format, you can declare multiple entity types that share the same definition using a single declaration. For example, `entity UserA, UserB, UserC` declares entity types `UserA`, `UserB`, and `UserC` that all have the same membership relations and shapes.
 
 ### Membership relations {#schema-entitytypes-memberOf}
 
@@ -77,7 +77,7 @@ Format composite data type declarations as follows.
 #### Record {#schema-entitytypes-shape-record}
 {: .no_toc }
 
-The specification of a record type is similar to that of a Cedar record, except that values of a record in the human-readable schema are types. For example, you can declare a record type as follows.
+The specification of a record type is similar to that of a Cedar policy record, except that values of a record in the schema are types. For example, you can declare a record type as follows.
 
 ```cedarschema
 {
@@ -148,11 +148,11 @@ The `appliesTo` construct specifies an action's applicability. It is a record of
 
 ## Common types {#schema-commonTypes}
 
-Like in the JSON schema format, human-readable schema syntax allows for declarations of common types so that entity type declarations can use them to avoid error-prone duplication. The syntax of common type declarations is similar to defining type aliases in most programming languages: `type <Id> = <Type>` . The `Type` is a schema type, including common types and types containing them. So, there is a chance there could be cycles in common type declarations: for instance, `type A = Set<B>; type B = {"a" : A};`. In these cases, the Cedar schema parser will report an error.
+Like in the JSON schema format, Cedar schema syntax allows for declarations of common types so that entity type declarations can use them to avoid error-prone duplication. The syntax of common type declarations is similar to defining type aliases in most programming languages: `type <Id> = <Type>` . The `Type` is a schema type, including common types and types containing them. So, there is a chance there could be cycles in common type declarations: for instance, `type A = Set<B>; type B = {"a" : A};`. In these cases, the Cedar schema parser will report an error.
 
 ## Type name disambiguation
 
-Type names in the human-readable schema format can conflict with each other. For example, `ipaddr` is a valid unqualified common type name as well as an extension type name. `Foo::Bar` is a valid qualified common type name and an entity type name. Cedar uses the following rules to disambiguate type names.
+Type names in the Cedar schema format can conflict with each other. For example, `ipaddr` is a valid unqualified common type name as well as an extension type name. `Foo::Bar` is a valid qualified common type name and an entity type name. Cedar uses the following rules to disambiguate type names.
 
 1. Primitive and extension type names cannot alias by design.
 2. Type references are resolved in a priority order.
@@ -200,7 +200,7 @@ namespace Demo {
 ```
 
  Common types and entity types can both be qualified with namespaces.
- The human-readable format allows *inline* declarations. Because of this, there may be conflicts between type names declared within a namespace and those declared using inline declarations. The resolution rule for this scenario is like *static scoping*: type names within the same namespace have higher priority. The following example demonstrates this rule.
+ The Cedar schema format allows *inline* declarations. Because of this, there may be conflicts between type names declared within a namespace and those declared using inline declarations. The resolution rule for this scenario is like *static scoping*: type names within the same namespace have higher priority. The following example demonstrates this rule.
 
  ```cedarschema
 type id = {

--- a/docs/collections/_schema/schema.md
+++ b/docs/collections/_schema/schema.md
@@ -16,7 +16,7 @@ nav_order: 1
 {:toc}
 </details>
 
-This topic describes the structure of a Cedar schema. Cedar has two schema formats: human-readable and JSON. The syntax of the human-readable schema format is very similar to that of Cedar policies. The JSON schema format is built from the [JSON Schema](https://json-schema.org/). Some unique aspects of the design of Cedar, like the use of entity types, differ from the common JSON schema. The two formats are interchangeable. The Cedar CLI can translate schemas in one format to the other. We encourage you to use the human-readable schema format for its simplicity and conciseness. For details, see [human-readable schema format](../schema/human-readable-schema.html) and [JSON schema format](../schema/json-schema.html).
+This topic describes the structure of a Cedar schema. Cedar has two schema formats: a human-readable format (which we call the Cedar format) and JSON. The syntax of the Cedar schema format is similar to that of Cedar policies. The JSON schema format is based on [JSON Schema](https://json-schema.org/), with some adaptations for unique aspects of Cedar, like the use of entity types. The two schema formats are interchangeable and the Cedar CLI can translate schemas in one format to the other. We encourage you to use the Cedar schema format for its simplicity and conciseness. For details, see [Cedar schema format](../schema/human-readable-schema.html) and [JSON schema format](../schema/json-schema.html).
 
 ## Overview {#schema-overview}
 A schema is a declaration of the structure of the entity types that you want to support in your application and for which you want Cedar to provide authorization services.
@@ -34,14 +34,14 @@ You can use a schema to define each of the following entities used by your appli
 
 Services that use Cedar can use the information provided in the schema to validate the policies you submit to the policy store. This helps prevent your policies from returning incorrect authorization decisions because of errors in policies like incorrectly typed attribute names. For more information about validating your policies, see [Cedar policy validation against schema](../policies/validation.html).
 
-Both schema formats implement the same ideas, which we detail as follows. We then present their human-readable anb JSON realizations.
+Both schema formats implement the same ideas, which we detail as follows. We then present their Cedar and JSON realizations.
 
 ## Schema {#schema-format}
 
 A schema contains a declaration of one or more namespaces, each of which contains declarations of entity types, actions, and common types. A namespace has an optional name.
 
 **Schema topics**
-* [Human-readable schema format](../schema/human-readable-schema.html#schema-format)
+* [Cedar schema format](../schema/human-readable-schema.html#schema-format)
 * [JSON schema format](../schema/json-schema.html#schema-format)
 
 ## Namespace {#schema-namespace}
@@ -64,7 +64,7 @@ Declarations (e.g, entity types) of a namespace must be qualified with its name 
 If you change a declared namespace in your schema you will need to change the entity types appearing in your policies and/or in other namespaces declared in your schema to instead reference the changed namespace.
 
 **Namespace topics**
-* [Human-readable schema format](../schema/human-readable-schema.html#schema-namespace)
+* [Cedar schema format](../schema/human-readable-schema.html#schema-namespace)
 * [JSON schema format](../schema/json-schema.html#schema-namespace)
 
 ## Entity types {#schema-entityTypes}
@@ -75,7 +75,7 @@ A collection of the `principal` and `resource` entity types supported by your ap
 >The entity type name must be normalized and cannot include any embedded whitespace, such as spaces, newlines, control characters, or comments.
 
 **Entity type topics**
-* [Human-readable schema format](../schema/human-readable-schema.html#schema-entityTypes)
+* [Cedar schema format](../schema/human-readable-schema.html#schema-entityTypes)
 * [JSON schema format](../schema/json-schema.html#schema-entityTypes)
 
 ### Membership relation
@@ -83,19 +83,19 @@ A collection of the `principal` and `resource` entity types supported by your ap
 Specifies a list of entity types that can be *direct* parents of entities of this type.
 
 **Membership topics**
-* [Human-readable schema format](../schema/human-readable-schema.html#schema-entitytypes-memberOf)
+* [Cedar schema format](../schema/human-readable-schema.html#schema-entitytypes-memberOf)
 * [JSON schema format](../schema/json-schema.html#schema-entitytypes-memberOf)
 
 ### Shape/Attributes
 
 Specifies the shape of the data stored in entities of this type. More precisely, it defines the attributes of an entity type --- their names, types, and optionality.
-An attribute type is one of the [Cedar supported data types](../policies/syntax-datatypes.html) or a common type, which have different representations in the human-readable format and the JSON format.
+An attribute type is one of the [Cedar supported data types](../policies/syntax-datatypes.html) or a common type, which have different representations in the Cedar format and the JSON format.
 You can choose to specify whether an attribute is required or optional. By default, attributes that you define are required. This means that policies that reference this type can assume that the attribute is always present.
 
 A policy should check for an optional attribute's presence by using the [`has`](../policies/syntax-operators.html#operator-has) operator before trying to access the attribute's value. If evaluation of a policy results in an attempt to access a non-existent attribute, evaluation fails with an error (which causes the policy to be ignored during authorization, and for a diagnostic to be generated). The validator will flag the potential for such errors to occur.
 
 **Shape topics**
-* [Human-readable schema format](../schema/human-readable-schema.html#schema-entitytypes-shape)
+* [Cedar schema format](../schema/human-readable-schema.html#schema-entitytypes-shape)
 * [JSON schema format](../schema/json-schema.html#schema-entitytypes-shape)
 
 ## Actions {#schema-actions}
@@ -105,7 +105,7 @@ A collection of the `Action` entities usable as actions in authorization request
 An action declaration specifies an action's membership relations with action groups, its applicability (with respect to principal and resource entity types, and the context shape).
 
 **Actions topics**
-* [Human-readable schema format](../schema/human-readable-schema.html#schema-actions)
+* [Cedar schema format](../schema/human-readable-schema.html#schema-actions)
 * [JSON schema format](../schema/json-schema.html#schema-actions)
 
 ## Common type {#schema-commonTypes}
@@ -114,7 +114,7 @@ Your schema might define several entity types that share a lot of elements in co
 
 ### Motivating example
 
-Suppose your schema defines several entity types or action entities that share a lot of elements in common. For example, consider the following actions in the human-readable schema format: both `view` and `upload` have identical `context` components.
+Suppose your schema defines several entity types or action entities that share a lot of elements in common. For example, consider the following actions in the Cedar schema format: both `view` and `upload` have identical `context` components.
 
 ```cedar
 action view appliesTo {
@@ -154,5 +154,5 @@ action upload appliesTo {
 ```
 
 **Common types topics**
-* [Human-readable schema format](../schema/human-readable-schema.html#schema-commonTypes)
+* [Cedar schema format](../schema/human-readable-schema.html#schema-commonTypes)
 * [JSON schema format](../schema/json-schema.html#schema-commonTypes)


### PR DESCRIPTION
*Issue #, if available:*

Part of #125

*Description of changes:*

Replace uses of "human-readable" with "Cedar" to match https://github.com/cedar-policy/cedar/pull/1114, which was released as part of 4.0. Note that I didn't change any filenames, because this would lead to new URLs, which could be a problem for anyone linking to these pages.