### PR TITLE
update policy grammar

### DIFF
--- a/docs/collections/_policies/syntax-grammar.md
+++ b/docs/collections/_policies/syntax-grammar.md
@@ -151,7 +151,7 @@ Member ::= Primary {Access}
 ## `Annotation` {#grammar-annotation}
 
 ```
-Annotation ::= '@'IDENT'('STR')'
+Annotation ::= '@'ANYIDENT'('STR')'
 ```
 
 ## `Access` {#grammar-access}
@@ -214,10 +214,16 @@ RecInits ::= (IDENT | STR) ':' Expr {',' (IDENT | STR) ':' Expr}
 RELOP ::= '<' | '<=' | '>=' | '>' | '!=' | '==' | 'in'
 ```
 
+## `ANYIDENT` {#grammar-any-ident}
+
+```
+ANYIDENT ::= ['_''a'-'z''A'-'Z']['_''a'-'z''A'-'Z''0'-'9']*
+```
+
 ## `IDENT` {#grammar-ident}
 
 ```
-IDENT ::= ['_''a'-'z''A'-'Z']['_''a'-'z''A'-'Z''0'-'9']* - RESERVED
+IDENT ::= ANYIDENT - RESERVED
 ```
 
 ## `STR` {#grammar-str}
@@ -253,7 +259,7 @@ INT ::= '-'? ['0'-'9']+
 ## `RESERVED` {#grammar-reserved}
 
 ```
-RESERVED ::= BOOL | 'if' | 'then' | 'else' | 'in' | 'like' | 'has' | '__cedar'
+RESERVED ::= BOOL | 'if' | 'then' | 'else' | 'in' | 'like' | 'has' | 'is' | '__cedar'
 ```
 
 ## `VAR` {#grammar-var}


### PR DESCRIPTION
*Issue #, if available:*

Resolves #129

*Description of changes:*

* Adds `is` to the list of reserved keywords
* Adds `ANYIDENT` rule for unrestricted identifiers

The current rule for extension functions `ExtFun ::= [Path '::'] IDENT` is technically incorrect since we check against the current extension functions at parse time (see https://github.com/cedar-policy/cedar/pull/1223), but it seems ugly to put that in the grammar, so I'm inclined to leave it out. 