### PR TITLE
Fix ipaddr.isInRange example

### DIFF
--- a/docs/collections/_policies/syntax-operators.md
+++ b/docs/collections/_policies/syntax-operators.md
@@ -1127,7 +1127,7 @@ ip("192.168.0.1").isInRange(ip("192.168.0.1/24"))   //true
 ip("192.168.0.1").isInRange(ip("192.168.0.1/28"))   //true
 ip("192.168.0.75").isInRange(ip("192.168.0.1/24"))  //true
 ip("192.168.0.75").isInRange(ip("192.168.0.1/28"))  //false
-ip("1:2:3:4::/48").isInRange(ip("1:2:3:4::"))       //true
+ip("1:2:3:4::").isInRange(ip("1:2:3:4::/48"))       //true
 ip("192.168.0.1").isInRange(ip("1:2:3:4::"))        //false
 ip("192.168.0.1").isInRange(1)                      //error - operand is not an ipaddr
 context.foo.isInRange(ip("192.168.0.1/24"))         //error if `context.foo` is not an `ipaddr`


### PR DESCRIPTION
The example says that `ip("1:2:3:4::/48").isInRange(ip("1:2:3:4::"))` evaluates to `true`, but the input arguments should be swapped for this to actually be the case.

```
$ cedar evaluate 'ip("1:2:3:4::/48").isInRange(ip("1:2:3:4::"))' --principal 'Principal::"foo"' --action 'Action::"foo"' --resource 'Resource::"foo"' 

false

$ cedar evaluate 'ip("1:2:3:4::").isInRange(ip("1:2:3:4::/48"))' --principal 'Principal::"foo"' --action 'Action::"foo"' --resource 'Resource::"foo"' 

true
```
