### PR TITLE
Update `like` spec in JSON policy format docs

### DIFF
--- a/docs/collections/_policies/json-format.md
+++ b/docs/collections/_policies/json-format.md
@@ -615,7 +615,6 @@ An JsonExpr object is an object with a single key that is any of the following.
 + [`.`, `has`](#JsonExpr-has)
 + [`is`](#JsonExpr-is)
 + [`like`](#JsonExpr-like)
-+ [`Literal`](#JsonExpr-Literal)
 + [`if-then-else`](#JsonExpr-if-then-else)
 + [`Set`](#JsonExpr-Set)
 + [`Record`](#JsonExpr-Record)

--- a/docs/collections/_policies/json-format.md
+++ b/docs/collections/_policies/json-format.md
@@ -937,6 +937,22 @@ A pattern element can be one of either
   - the string `Wildcard`
   - an object with a single key `Literal`, whose value is a string
 
+**Example for `pattern`**
+
+The pattern `/home/alice/docs/*.txt` is represented as:
+
+```json
+"pattern": [
+  {
+    "Literal": "/home/alice/docs/"
+  },
+  "Wildcard",
+  {
+    "Literal": ".txt"
+  }
+]
+```
+
 #### `if-then-else` {#JsonExpr-if-then-else}
 
 The value of this key is an object with keys `if`, `then`, and `else`, each of which are themselves an [JsonExpr object](#JsonExpr-objects).

--- a/docs/collections/_policies/json-format.md
+++ b/docs/collections/_policies/json-format.md
@@ -936,12 +936,7 @@ The value of this key is an object with keys `left` and `pattern`.
 The left key is itself an [JsonExpr object](#JsonExpr-objects), while the `pattern` key is an array composed of pattern elements.
 A pattern element can be one of either
   - the string `Wildcard`
-  - a [`Literal`](#JsonExpr-Literal)
-
-#### `Literal` {#JsonExpr-Literal}
-
-The value of this key is a string.
-Note that this object is only used in [`like`](#JsonExpr-Like) patterns at the moment.
+  - an object with a single key `Literal`, whose value is a string
 
 #### `if-then-else` {#JsonExpr-if-then-else}
 

--- a/docs/collections/_policies/json-format.md
+++ b/docs/collections/_policies/json-format.md
@@ -615,6 +615,7 @@ An JsonExpr object is an object with a single key that is any of the following.
 + [`.`, `has`](#JsonExpr-has)
 + [`is`](#JsonExpr-is)
 + [`like`](#JsonExpr-like)
++ [`Literal`](#JsonExpr-Literal)
 + [`if-then-else`](#JsonExpr-if-then-else)
 + [`Set`](#JsonExpr-Set)
 + [`Record`](#JsonExpr-Record)
@@ -931,7 +932,16 @@ JSON representation
 
 #### `like` {#JsonExpr-like}
 
-The value of this key is an object with keys `left` and `pattern`.  The left key is itself an [JsonExpr object](#JsonExpr-objects), while the `pattern` key is any string.
+The value of this key is an object with keys `left` and `pattern`.
+The left key is itself an [JsonExpr object](#JsonExpr-objects), while the `pattern` key is an array composed of pattern elements.
+A pattern element can be one of either
+  - the string `Wildcard`
+  - a [`Literal`](#JsonExpr-Literal)
+
+#### `Literal` {#JsonExpr-Literal}
+
+The value of this key is a string.
+Note that this object is only used in [`like`](#JsonExpr-Like) patterns at the moment.
 
 #### `if-then-else` {#JsonExpr-if-then-else}
 

--- a/docs/collections/_policies/json-format.md
+++ b/docs/collections/_policies/json-format.md
@@ -953,6 +953,9 @@ The pattern `/home/alice/docs/*.txt` is represented as:
 ]
 ```
 
+Note that it's allowed to represent literals with up to one `Literal` per character.
+For instance, in the previous example, we could use up to four objects with `Literal` keys to represent the `.txt` string.
+
 #### `if-then-else` {#JsonExpr-if-then-else}
 
 The value of this key is an object with keys `if`, `then`, and `else`, each of which are themselves an [JsonExpr object](#JsonExpr-objects).


### PR DESCRIPTION
*Issue #, if available:* Resolves #147

*Description of changes:* Makes a correction to the JSON policy format documentation regarding the `pattern` attribute of the `like` operator. It seems that the implementation changed in https://github.com/cedar-policy/cedar/pull/622 but the documentation was never updated to reflect the changes.
