### PR TITLE
Reduce confusion when looking at action groups example.

### DIFF
--- a/docs/collections/_policies/policy-examples.md
+++ b/docs/collections/_policies/policy-examples.md
@@ -141,11 +141,9 @@ A better way to set the properties of actions in your schema, however, is to arr
 ```Cedar
 permit(
   principal == PhotoFlash::User::"alice",
-  action,
+  action in PhotoFlash::Action::"ReadOnlyPhotoAccess",
   resource
-) when {
-    action in PhotoFlash::Action::"ReadOnlyPhotoAccess"
-};
+);
 ```
 This following example shows how you might create a policy that allows all principals to perform any action on resources for which they have `owner` attribute.
 ```Cedar


### PR DESCRIPTION
When reading through the examples, the one on action groups is structured differently to the others, with the action filter done in the `when` condition instead of the scope. I have seen this lead to confusion as to whether it was possible to use action groups in scopes. This PR changes the example to use the scope which reduces that confusion and makes the example more consistent with the other action examples.

