### PR TITLE
Renames Cedar Type "Boolean" to "Bool" to match human-readable schema name.

### DIFF
--- a/docs/collections/_auth/entities-syntax.md
+++ b/docs/collections/_auth/entities-syntax.md
@@ -59,7 +59,7 @@ Notice that the `department` attribute has a string value, and the `jobLevel` at
 
 + JSON string --> [Cedar String](../policies/syntax-datatypes.html#datatype-string)
 + JSON integer --> [Cedar Long](../policies/syntax-datatypes.html#datatype-long)
-+ JSON boolean --> [Cedar Boolean](../policies/syntax-datatypes.html#datatype-boolean)
++ JSON boolean --> [Cedar Bool](../policies/syntax-datatypes.html#datatype-bool)
 + JSON list/array --> [Cedar Set](../policies/syntax-datatypes.html#datatype-set)
 + JSON object/map --> [Cedar Record](../policies/syntax-datatypes.html#datatype-record)
 

--- a/docs/collections/_policies/syntax-datatypes.md
+++ b/docs/collections/_policies/syntax-datatypes.md
@@ -18,7 +18,7 @@ The Cedar policy language supports values and expressions of several possible da
 {:toc}
 </details>
 
-## Boolean {#datatype-boolean}
+## Bool {#datatype-bool}
 
 A value that is either `true` or `false`.
 
@@ -47,7 +47,7 @@ A collection of elements that can be of the same or different types. A set is co
 // an empty set
 [ ]
 
-// a set with a Boolean expression, a nested set, and a Boolean value
+// a set with a Bool expression, a nested set, and a Bool value
 [3<5, ["nested", "set"], true]
 ```
 

--- a/docs/collections/_policies/syntax-grammar.md
+++ b/docs/collections/_policies/syntax-grammar.md
@@ -88,7 +88,7 @@ Resource ::= 'resource' [(['is' PATH] ['in' (Entity | '?resource')]) | ('==' (En
 
 ## `Condition` {#grammar-condition}
 
-A `Condition` consists of either the `when` or `unless` keyword followed by a Boolean expression surrounded by braces `{ }`. A `when` clause matches the request when the expression evaluates to `true`. An `unless` clause matches the request when the expression \(an [Expr](#grammar-expr) element\) evaluates to `false`.
+A `Condition` consists of either the `when` or `unless` keyword followed by a Bool expression surrounded by braces `{ }`. A `when` clause matches the request when the expression evaluates to `true`. An `unless` clause matches the request when the expression \(an [Expr](#grammar-expr) element\) evaluates to `false`.
 
 The parent [Policy](#grammar-policy) element can have zero or more `when` or `unless` clauses.
 

--- a/docs/collections/_schema/human-readable-schema.md
+++ b/docs/collections/_schema/human-readable-schema.md
@@ -74,7 +74,7 @@ Note that if you omit attribute declarations, then entities of this type don't h
 
 Schema types can be used as right-hand side of an attribute or common type declaration.
 
-Cedar data types have corresponding schema types. The corresponding type names of Cedar primitive data types [Boolean](../policies/syntax-datatypes.html#datatype-boolean), [String](../policies/syntax-datatypes.html#datatype-string), [Long](../policies/syntax-datatypes.html#datatype-string) are `Bool`, `String`, `Long`, respectively.
+Cedar data types have corresponding schema types. The corresponding type names of Cedar primitive data types [Bool](../policies/syntax-datatypes.html#datatype-bool), [String](../policies/syntax-datatypes.html#datatype-string), [Long](../policies/syntax-datatypes.html#datatype-string) are `Bool`, `String`, `Long`, respectively.
 
 An entity type or an extension type is specified by its name. The entity type name is an identifier or identifiers separated by `::`. For example, both `User` and `ExampleCo::User` are valid entity type names.
 


### PR DESCRIPTION
Does not rename occurrences of "Boolean" within grammars and/or JSON schema names.


