### PR TITLE
Typo fixes in Cedar policies docs

### DIFF
--- a/docs/collections/_policies/json-format.md
+++ b/docs/collections/_policies/json-format.md
@@ -367,7 +367,7 @@ The `op` object must have one of the following string values:
     Cedar policy line:
 
     ```cedar
-    action in [ Action:: "ManageFiles", Action::"readFile", Action::"writeFile", Action::"deleteFile"]
+    action in [ Action::"ManageFiles", Action::"readFile", Action::"writeFile", Action::"deleteFile"]
     ```
 
     JSON representation
@@ -575,7 +575,7 @@ The value of this object is a JSON array of objects.  Each object in the array m
 
 The `kind` key must be either the string `when` or the string `unless`.
 
-The `body` key must be an [JsonExpr object](#JsonExpr-objects).
+The `body` key must be a [JsonExpr object](#JsonExpr-objects).
 
 **Example**
 
@@ -815,7 +815,7 @@ The value of this key is an object with a single key name, whose value is the na
 
 #### `!`, `neg`, and `isEmpty` operators {#JsonExpr-neg}
 
-The value of this key is an object with a single key argument, whose value is itself an [JsonExpr object](#JsonExpr-objects).
+The value of this key is an object with a single key argument, whose value is itself a [JsonExpr object](#JsonExpr-objects).
 
 **Example using `.` and `!`**
 
@@ -849,7 +849,7 @@ JSON representation
 
 #### Binary operators: `==`, `!=`, `in`, `<`, `<=`, `>`, `>=`, `&&`, `||`, `+`, `-`, `*`, `contains`, `containsAll`, `containsAny`, `hasTag`, `getTag` {#JsonExpr-binary}
 
-The value for any of these keys is an object with keys `left` and `right`, which are each themselves an [JsonExpr object](#JsonExpr-objects).
+The value for any of these keys is an object with keys `left` and `right`, which are each themselves a [JsonExpr object](#JsonExpr-objects).
 
 **Example for `contains`**
 
@@ -887,7 +887,7 @@ JSON representation
 
 #### `.` {#JsonExpr-member}
 
-The value of one of these keys is an object with keys `left` and `attr`.  The left key is itself an [JsonExpr object](#JsonExpr-objects), while the `attr` key is a string.
+The value of one of these keys is an object with keys `left` and `attr`.  The left key is itself a [JsonExpr object](#JsonExpr-objects), while the `attr` key is a string.
 
 **Example for `.`**
 
@@ -910,7 +910,7 @@ JSON representation
 
 #### `has` {#JsonExpr-has}
 
-The value of one of these keys is an object with keys `left` and `attr`.  The left key is itself an [JsonExpr object](#JsonExpr-objects), while the `attr` key is a string or a non-empty list of identifiers.
+The value of one of these keys is an object with keys `left` and `attr`.  The left key is itself a [JsonExpr object](#JsonExpr-objects), while the `attr` key is a string or a non-empty list of identifiers.
 
 
 **Example for `has`**
@@ -953,7 +953,7 @@ JSON representation
 #### `is` {#JsonExpr-is}
 
 The value of this key is an object with the keys `left` and `entity_type`.
-The `left` key is itself an [JsonExpr object](#JsonExpr-objects), while the `entity_type` key is a string.
+The `left` key is itself a [JsonExpr object](#JsonExpr-objects), while the `entity_type` key is a string.
 The value may optionally have an `in` key which is also a JsonExpr object.
 
 **Example for `is`**
@@ -970,14 +970,14 @@ JSON representation
 "is": {
     "left": { "Var": "principal" },
     "entity_type": "User",
-    "in": {"Value": {"__entity": { "type": "Folder", "id": "Public" }}}
+    "in": {"Value": {"__entity": { "type": "Group", "id": "friends" }}}
 }
 ```
 
 #### `like` {#JsonExpr-like}
 
 The value of this key is an object with keys `left` and `pattern`.
-The left key is itself an [JsonExpr object](#JsonExpr-objects), while the `pattern` key is an array composed of pattern elements.
+The left key is itself a [JsonExpr object](#JsonExpr-objects), while the `pattern` key is an array composed of pattern elements.
 A pattern element can be one of either
   - the string `Wildcard`
   - an object with a single key `Literal`, whose value is a string
@@ -1003,7 +1003,7 @@ For instance, in the previous example, we could use up to four objects with `Lit
 
 #### `if-then-else` {#JsonExpr-if-then-else}
 
-The value of this key is an object with keys `if`, `then`, and `else`, each of which are themselves an [JsonExpr object](#JsonExpr-objects).
+The value of this key is an object with keys `if`, `then`, and `else`, each of which are themselves a [JsonExpr object](#JsonExpr-objects).
 
 **Example for if-then-else**
 
@@ -1062,7 +1062,7 @@ JSON representation
 
 #### `Set` {#JsonExpr-Set}
 
-The value of this key is a JSON array of values, each of which is itself an [JsonExpr object](#JsonExpr-objects).
+The value of this key is a JSON array of values, each of which is itself a [JsonExpr object](#JsonExpr-objects).
 
 **Example**
 
@@ -1098,7 +1098,7 @@ JSON representation
 ```json
 {
     "Record": {
-        "foo": { "Value": "spam" },
+        "something": { "Value": "spam" },
         "somethingelse": { "Value": false },
     }
 }
@@ -1106,7 +1106,7 @@ JSON representation
 
 #### Any other key {#JsonExpr-any-other-key}
 
-This key is treated as the name of an extension function or method.  The value must be a JSON array of values, each of which is itself an [JsonExpr object](#JsonExpr-objects).  Note that for method calls, the method receiver is the first argument.  For example, for `a.isInRange(b)`, the first argument is for `a` and the second argument is for `b`.
+This key is treated as the name of an extension function or method.  The value must be a JSON array of values, each of which is itself a [JsonExpr object](#JsonExpr-objects).  Note that for method calls, the method receiver is the first argument.  For example, for `a.isInRange(b)`, the first argument is for `a` and the second argument is for `b`.
 
 **Example for `decimal` function**
 
@@ -1264,7 +1264,7 @@ This field is a JSON array of template links. The JSON representation of a templ
 * `newId`
 * `values`
 
-`templateId` is the ID of the policy to be linked against. `new_id` is the ID of the newly generated template-linked policy, and `values` is a mapping from slots (`?principal` or `?resource`) to entities.
+`templateId` is the ID of the policy to be linked against. `newId` is the ID of the newly generated template-linked policy, and `values` is a mapping from slots (`?principal` or `?resource`) to entities.
 
 ## Convert Cedar policy format to JSON policy format using Java
 

--- a/docs/collections/_policies/level-validation.md
+++ b/docs/collections/_policies/level-validation.md
@@ -8,9 +8,9 @@ nav_order: 9
 {: .no_toc }
 
 Cedar [authorization requests](../auth/authorization.html) require evaluating policies given a `principal`, `action`, `resource`, `context`, and all entity data that could be relevant for that request.
-This may sound straight-forward at first, but it's not always obvious what entity data is actually relevant for a particular request.
+This may sound straightforward at first, but it's not always obvious what entity data is actually relevant for a particular request.
 If our only concern is always selecting all relevant data, then we can take the easiest option and select _all_ entity data.
-It always safe to include all entity data, but, for applications with a large amount of entity data, using all of it for every request might be too difficult or expensive.
+It is always safe to include all entity data, but, for applications with a large amount of entity data, using all of it for every request might be too difficult or expensive.
 
 Cedar provides level validation to help applications limit the amount of entity data required for authorization requests.
 Level validation is an extra validation stage performed after standard policy validation.
@@ -44,8 +44,8 @@ Level validation specifically restricts entity dereferencing expressions - opera
 These operations may fail or return unexpected results if they attempt to access data for entities not included in the authorization request, so they need to be restricted in order to be sure a policy doesn't depend on data that the slicing procedure won't collect.
 
 * **Entity Attribute operations**: Attribute access (`.`) and presence test (`has`) operations on entities require entity data to inspect the attributes of the target expression. These operations apply to records where they are not restricted by level validation.
-* **Tag operations**: Tag access (`getTag`) and presence test (`hasTag`) operations require entity data to inspect the tags of the target expression. These are binary operator, but level validation only restricts their first operand.
-* **Hierarchy membership**: The binary `in` operator needs to access the list of ancestors entities for its first operand. Level validation does not restrict the second operand because `in` does not need to know its ancestor entities.
+* **Tag operations**: Tag access (`getTag`) and presence test (`hasTag`) operations require entity data to inspect the tags of the target expression. These are binary operators, but level validation only restricts their first operand.
+* **Hierarchy membership**: The binary `in` operator needs to access the list of ancestor entities for its first operand. Level validation does not restrict the second operand because `in` does not need to know its ancestor entities.
 
 All other operations are unrestricted by level validation, needing only to follow the rules enforced by regular policy validation.
 
@@ -97,7 +97,7 @@ Level validation restricts all dereferencing expressions on entity literals, reg
 Entity literals are not represented anywhere in the principal, action, resource or context of an authorization request so cannot be collected by the level-based slicing procedure.
 If level validation allowed access to attributes of entity literals, it would not be able to guarantee that data for that literal was selected during entity slicing, meaning that the authorization decision for a request depending on that entity could change.
 
-The following expressions are not accepted at any level because they deference an entity literal.
+The following expressions are not accepted at any level because they dereference an entity literal.
 ```cedar
 User::"alice".is_admin
 User::"alice" has manager
@@ -109,14 +109,14 @@ Doc::"my_doc" in principal.folder
 Level validation places a limit on how much entity data a policy can access.
 Given an authorization request, level-based entity slicing takes advantage of this limit to select a subset of the entity data that we know will contain all relevant data required for evaluating the request.
 The exact implementation of this procedure will depend on how your entity data is stored, so the Cedar library doesn't provide an implementation.
-If your entity data is stored in database, you will want to implement entity slicing using database queries to efficiently extract only the required entities without loading the full database into memory.
+If your entity data is stored in a database, you will want to implement entity slicing using database queries to efficiently extract only the required entities without loading the full database into memory.
 
 The level-based entity slicing algorithm is an iterative procedure that works in general for slicing at any level, but an application which always validates and slices at a fixed level may not need to implement the fully general algorithm.
 For example, if all policies in an application validate at level 0, then the algorithm can be unrolled assuming slicing at level 0 which always results in selecting an empty set of entity data.
 In other words, no entity data is ever required if policies validate at level 0.
 
 If all policies validate at level 1, then the application would need to unroll 1 iteration of the procedure.
-This is accomplished by taking the exactly entity UIDs from the request (`principal`, `action`, `resource`, and any entities referenced in `context`) and retrieving their entity data.
+This is accomplished by taking the exact entity UIDs from the request (`principal`, `action`, `resource`, and any entities referenced in `context`) and retrieving their entity data.
 
 The general level-based slicing algorithm applicable at any level *n* starts from the entities in the request, and follows their attributes and tags to discover all entities reachable in *n* access operations.
 
@@ -129,7 +129,7 @@ The general level-based slicing algorithm applicable at any level *n* starts fro
    - For each entity identifier in the *working set*
      - Lookup the corresponding entity data
      - Insert the entity data into the *slice*
-     - Insert into the *next working set* all entity identifiers referenced by the attribute or tags in the *entity data*
+     - Insert into the *next working set* all entity identifiers referenced by the attributes or tags in the *entity data*
    - Set the *working set* to be equal to the *next working set* and continue iteration
 
 At the end of the procedure, the *slice* is now the final set of entity data, containing all the entity data that could possibly be accessed by policies validated at level *n*.

--- a/docs/collections/_policies/policy-examples.md
+++ b/docs/collections/_policies/policy-examples.md
@@ -73,7 +73,7 @@ permit(
   principal == User::"alice", 
   action in [PhotoflashRole::"viewer", Action::"edit"],
   resource in Album::"alice_vacation"
-)
+);
 ```
 ## Allows access for any entity {#allow-any}
 This following example shows how you might create a policy that allows any authenticated principal to view the album `alice_vacation`.
@@ -92,7 +92,7 @@ permit(
   resource in Account::"jane"
 );
 ```
-This following example shows how you might create a policy that allows the user `alice` to perform any action on resources in the album `jane_vaction`.
+This following example shows how you might create a policy that allows the user `alice` to perform any action on resources in the album `jane_vacation`.
 ```Cedar
 permit(
   principal == User::"alice", 

--- a/docs/collections/_policies/syntax-datatypes.md
+++ b/docs/collections/_policies/syntax-datatypes.md
@@ -204,7 +204,7 @@ You specify values of extension type `ipaddr` using the [ip() operator](../polic
 
 ```cedar
 ip("192.168.1.100")    // a single IPv4 address
-ip("10.50.0.0/24")     // an IPv4 range with a 24-bit subnet mask (255.255.0.0)
+ip("10.50.0.0/24")     // an IPv4 range with a 24-bit subnet mask (255.255.255.0)
 ip("1:2:3:4::/48")     // an IPv6 range with a 48-bit subnet mask
 ```
 

--- a/docs/collections/_policies/syntax-grammar.md
+++ b/docs/collections/_policies/syntax-grammar.md
@@ -61,7 +61,7 @@ Scope ::= Principal ',' Action ',' Resource
 The `Principal` element consists of the `principal` keyword. If specified by itself, the policy statement matches *any* principal.
 
 Optionally, the keyword can be followed by either the [`in`](../policies/syntax-operators.html#operator-in), [`==`](../policies/syntax-operators.html#operator-equality), or [`is`](../policies/syntax-operators.html#operator-is) operator.
-An `is` operator may appear together with an `in` operators, but not an `==` operator.
+An `is` operator may appear together with an `in` operator, but not an `==` operator.
 The `in` and `==` operators are followed by either an `Entity`, or the `?principal` placeholder when used in a policy template.
 
 ```
@@ -79,7 +79,7 @@ Action ::= 'action' [( '==' Entity | 'in' ('[' EntList ']' | Entity) )]
 ## `Resource` {#grammar-resource}
 
 The `Resource` consists of the `resource` keyword. If specified by itself, it matches any resource. Optionally, it can be followed by either the [`in`](../policies/syntax-operators.html#operator-in), [`==`](../policies/syntax-operators.html#operator-equality), or [`is`](../policies/syntax-operators.html#operator-is) operator.
-An `is` operator may appear together with an `in` operators, but not an `==` operator.
+An `is` operator may appear together with an `in` operator, but not an `==` operator.
 The `in` and `==` operators are followed by either an `Entity`, or the `?resource` placeholder when used in a policy template.
 
 ```

--- a/docs/collections/_policies/syntax-operators.md
+++ b/docs/collections/_policies/syntax-operators.md
@@ -70,7 +70,7 @@ Functions use one of two styles of syntax:
   ```cedar
   firstOperand.function(secondOperand, thirdOperand, …)
 
-  // Evaluates to true if the any of the set member
+  // Evaluates to true if any of the set members
   // elements b, c, or d is an element of set a
   a.containsAny([b, c, d])
   ```
@@ -220,7 +220,7 @@ decimal("0.12345")               //error - too many fractional digits
 
 Function that parses the string and tries to convert it to type [duration](syntax-datatypes.html#datatype-duration). If the string doesn't represent a valid duration value, it generates an error.
 
-To be interpreted successfully as a datetime value, the string must be a concatenated sequence of quantity-unit pairs where the quantity part is a natural number and the unit is one of the following:
+To be interpreted successfully as a duration value, the string must be a concatenated sequence of quantity-unit pairs where the quantity part is a natural number and the unit is one of the following:
 - `d`: days
 - `h`: hours
 - `m`: minutes
@@ -547,7 +547,7 @@ Assume that `resource.creationDate` is `"2024-10-15T11:38:33Z"`.
 
 ```cedar
 datetime("1970-01-02") > datetime("1970-01-01")                    //true
-datetime(resource.creationDate) > datetime("2024-10-15T11:38:33Z") //true
+datetime(resource.creationDate) > datetime("2024-10-15T11:38:33Z") //false
 datetime("1970-01-01T01:00:00Z") > 3600000                         //error - operator not allowed on non-datetime
 ```
 
@@ -591,7 +591,7 @@ decimal("-1.23").greaterThan(decimal("-1.24"))  //true
 decimal("1.1").greaterThan(2)                   //error -- not a decimal operand
 ip("1.1.2.3").greaterThan(decimal("1.2"))       //error -- not a decimal operand
 ```
-The `greaterThan` function must take two `decimal` operands or else it will produce an error when evaluated, per the last two examples. The policy validator also rejects also any expression that attempts to call `greaterThan` on non-`decimal` values.
+The `greaterThan` function must take two `decimal` operands or else it will produce an error when evaluated, per the last two examples. The policy validator also rejects any expression that attempts to call `greaterThan` on non-`decimal` values.
 
 ### `>=` \(long integer 'greater than or equal'\) {#operator-greaterthanorequal}
 
@@ -611,7 +611,7 @@ principal.age >= 21    //true (assuming principal.age is 21)
 false >= true          //error - operands are not long integers
 "some" >= "thing"      //error - operands are not long integers
 ```
-As shown in the examples, evaluating an expression with `>=` when the operators are not both `long` numbers results in an error. The policy validator also rejects also any expression that attempts to compare two values with `>=` that do not have type `long`.
+As shown in the examples, evaluating an expression with `>=` when the operands are not both `long` numbers results in an error. The policy validator also rejects any expression that attempts to compare two values with `>=` that do not have type `long`.
 
 ### `>=` \(datetime 'greater than or equal'\) {#operator-greaterthanorequal-datetime}
 
@@ -695,7 +695,7 @@ The `&&` operator uses [short circuit evaluation](https://wikipedia.org/wiki/Sho
 The following policy is satisfied only if the principal has the attribute `level` and the `level > 5`.
 
 ```cedar
-permit (principal, action == Action:"read", resource)
+permit (principal, action == Action::"read", resource)
 when {
     principal has level &&
     principal.level > 5
@@ -739,7 +739,7 @@ The second comparison in this expression will evaluate to a boolean only if the 
 The following policy allows if either `resource.owner == principal` or `resource.tag == "public"` is true.
 
 ```cedar
-permit (principal, action == Action:"read", resource)
+permit (principal, action == Action::"read", resource)
 when {
     resource.owner == principal ||
     resource.tag == "public"
@@ -760,7 +760,7 @@ false || 3                 //error (second operand not a boolean)
 (3 == 3) || 3              //Evaluates to true (due to short-circuiting) //Doesn't validate
 ```
 
-As mentioned above, validation _sometimes_ is able to account for short-circuiting behavior, but not always. In particular, the validator will accept `true || 3` but not `(3 == 3) && 3`.
+As mentioned above, validation _sometimes_ is able to account for short-circuiting behavior, but not always. In particular, the validator will accept `true || 3` but not `(3 == 3) || 3`.
 
 ### `!` \(NOT\) {#operator-not}
 
@@ -1124,7 +1124,7 @@ The validator will reject any `has` expression whose left-hand operand is not an
 
 **Usage:** `<entity>.hasTag(<expr>)`
 
-Method that evalutes to `true` if the entity on the left has a value defined for the tag name specified on the right. Unlike for attributes with [`has`](#operator-has), for tags the tag name may be any (string-typed) expression, and does not have to be a string literal. Evaluation (and validation) produces an error if `<entity>` is not an entity or if `<expr>` does not evaluate to a string.
+Method that evaluates to `true` if the entity on the left has a value defined for the tag name specified on the right. Unlike for attributes with [`has`](#operator-has), for tags the tag name may be any (string-typed) expression, and does not have to be a string literal. Evaluation (and validation) produces an error if `<entity>` is not an entity or if `<expr>` does not evaluate to a string.
 
 In all other respects, `.hasTag()` behaves similarly to [`has`](#operator-has) except that it
 operates on tags instead of attributes. (And only entities, not records, can have tags.)
@@ -1322,7 +1322,7 @@ context.foo.isIpv4()         //error if `context.foo` is not an `ipaddr`
 
 **Usage:** `<ipaddr>.isIpv6()`
 
-Function that evaluates to `true` if the receiver is an IPv6 address; evaluates (and validates) to an error if received does not have `ipaddr` type. This function takes no operand.
+Function that evaluates to `true` if the receiver is an IPv6 address; evaluates (and validates) to an error if receiver does not have `ipaddr` type. This function takes no operand.
 
 #### Examples:
 {: .no_toc }
@@ -1402,7 +1402,7 @@ Use these functions to operate on [`datetime`](./syntax-datatypes.html#datatype-
 **Usage:** `<datetime>.offset(<duration>)`
 
 Function that returns a new `datetime` value offset by the given `duration`.
-This function evaluates (and validates) to an error the first operand does not have `datetime` type or the second operand does not have `duration` type.
+This function evaluates (and validates) to an error if the first operand does not have `datetime` type or the second operand does not have `duration` type.
 The function evaluates to an error if the computation would exceed the representable range for the `datetime` type.
 
 #### Examples:
@@ -1573,7 +1573,7 @@ This function evaluates (and validates) to an error if receiver does not have `d
 In the examples that follow, those labeled `//error` both evaluate and validate to an error.
 
 ```cedar
-duration("1d").toDays()      // returns `long` equal to 24
+duration("1d").toDays()      // returns `long` equal to 1
 duration("4d10h").toDays()   // returns `long` equal to 4
 duration("4d30h").toDays()   // returns `long` equal to 5
 duration("100ms").toDays()   // returns `long` equal to 0

--- a/docs/collections/_policies/syntax-policy.md
+++ b/docs/collections/_policies/syntax-policy.md
@@ -258,7 +258,7 @@ You can attach arbitrary key-value pairs to Cedar policies in the form of annota
 
 You can place annotations only at the very top of the policy before the [effect](#term-policy-effect) element.
 
-**Note**: `@id`is not special in the Cedar language, it behaves like any other annotation. The Cedar CLI uses the `@id` annotation to set policy IDs, but other interfaces, such as the Cedar APIs, have other ways to set policy IDs.
+**Note**: `@id` is not special in the Cedar language, it behaves like any other annotation. The Cedar CLI uses the `@id` annotation to set policy IDs, but other interfaces, such as the Cedar APIs, have other ways to set policy IDs.
 
 An annotation has the following form:
 

--- a/docs/collections/_policies/validation.md
+++ b/docs/collections/_policies/validation.md
@@ -121,7 +121,7 @@ The validator compares a policy with a schema to look for inconsistencies. From 
 + **Unrecognized attributes** &ndash; For example, `principal.jobbLevel` has a typo and should be `jobLevel`.
 + **Unsafe access to optional attributes** &ndash; For example, `principal.numberOfLaptops` where `numberOfLaptops` is an optional attribute declared with `required : false`. Such tests should be guarded by including a [`has`](../policies/syntax-operators.html#operator-has) check as the left side of the shortcircuiting [&&](../policies/syntax-operators.html#operator-and) expression. For example, as in `principal has numberOfLaptops && principal.numberOfLaptops > 1`.
 + **Type mismatch in operators** &ndash; For example, `principal.jobLevel > "14"` is an invalid comparison with a `String`.
-+ ** Invalid entity literals of enumerated entity types ** &ndash; For example, `Application::"TinyTODO"` is an invalid entity literal if entity type `Application` is an enumerated type and `TinyTodo` is the only allowed EID.
++ **Invalid entity literals of enumerated entity types** &ndash; For example, `Application::"TinyTODO"` is an invalid entity literal if entity type `Application` is an enumerated type and `TinyTodo` is the only allowed EID.
 
 The validator also looks for some suspicious situations that, while not runtime errors, are likely to be incorrect code.
 These are reported as the following warnings:


### PR DESCRIPTION
Typos and small mistakes identified by Claude. I have checked all of these myself.