### PR TITLE
Typo fix in example policy

### DIFF
--- a/docs/collections/_policies/policy-examples.md
+++ b/docs/collections/_policies/policy-examples.md
@@ -71,7 +71,7 @@ This following example shows how you might create a policy that allows permissio
 ```Cedar
 permit(
   principal == User::"alice", 
-  action in [PhotoflashRole::"viewer", Action::"edit"],
+  action in [Photoflash::Role::"viewer", Action::"edit"],
   resource in Album::"alice_vacation"
 );
 ```


### PR DESCRIPTION
See preceding example which uses `Photoflash::Role` 
