### PR TITLE
Fix errors in documentation examples

### DIFF
--- a/docs/collections/_auth/integration-express.md
+++ b/docs/collections/_auth/integration-express.md
@@ -152,12 +152,12 @@ The Cedar authorizer requires user groups and attributes to authorize requests. 
 async function principalEntityFetcher(req) {
     const user = req.user;   // it's common practice for the authn middleware to store the user info from the decoded token here
     const userGroups = user["groups"].map(userGroupId => ({
-        type: 'PetStoreApp::UserGroup',
+        type: 'YourNamespace::UserGroup',
         id: userGroupId       
     }));
     return {
         uid: {
-            type: 'PetStoreApp::User',
+            type: 'YourNamespace::User',
             id: user.sub
         },
         attrs: {

--- a/docs/collections/_bestpractices/bp-normalize-data-input.md
+++ b/docs/collections/_bestpractices/bp-normalize-data-input.md
@@ -13,7 +13,7 @@ As a result, application owners should format data prior to passing it into the 
 
 ```json
 {
-  "url": "https://example.com/path/to/page?name=alice&amp;color=red"
+  "url": "https://example.com/path/to/page?name=alice&color=red"
 }
 ```
 
@@ -24,11 +24,12 @@ The information should be pre-formatted into something more accessible by policy
   "url": {
     "transport": "https",
     "host": "example.com",
-    "path": "/path/to/page"
+    "path": "/path/to/page",
     "queryParams": {
       "name": "alice",
       "color": "red"
     }
+  }
 }
 ```
 
@@ -36,7 +37,7 @@ Special attention should be paid to the normalization of strings. For example, c
 
 ```json
 {
-  "url": "https://EXAMPLE.COM////path/to/page?name=alice&amp;color=red"
+  "url": "https://EXAMPLE.COM////path/to/page?name=alice&color=red"
 }
 ```
 

--- a/docs/collections/_bestpractices/bp-populate-policy-scope.md
+++ b/docs/collections/_bestpractices/bp-populate-policy-scope.md
@@ -68,7 +68,7 @@ permit(
     principal in App::Role::"analyst",
     action == App::Action::"ViewReport",
     resource
-)
+);
 ```
 
 By modeling the role as a group entity that users are members of, you populate the principal scope. The authorization engine can index on this and skip the policy entirely for principals who are not in the `analyst` group.

--- a/docs/collections/_overview/patterns.md
+++ b/docs/collections/_overview/patterns.md
@@ -153,15 +153,15 @@ If we group audits by country then we can create a membership policy for each co
 ```cedar
 permit ( 
   principal in Role::"ComplianceOfficerCanada", 
-   action in [Action::"approveAudit"],
+   action in Action::"approveAudit",
    resource in AuditGroup::"AUDITS_CANADA"
-) ;
+);
 
 permit ( 
   principal in Role::"ComplianceOfficerUSA", 
-  action in [Action::"approveAudit"],
+  action in Action::"approveAudit",
   resource in AuditGroup::"AUDITS_USA"
-) ;
+);
 ```
 
 However, this approach may not scale well, leading to an explosion in the number of roles the organization has to manage if they operate in many countries. 
@@ -170,11 +170,11 @@ A third approach is to create a role-associated attribute. This is an attribute 
 ```cedar
 permit ( 
   principal in Role::"ComplianceOfficer", 
-   action in [Action::"approveAudit"],
+   action in Action::"approveAudit",
    resource is Audit) 
 when {
  principal has complianceOfficerCountries &&
- resource.country in principal.complianceOfficerCountries 
+ principal.complianceOfficerCountries.contains(resource.country)
 }; 
 ```
 
@@ -241,7 +241,7 @@ when {
   resource has viewingUsers && principal in resource.viewingUsers 
 }
 unless { 
-  resource has isPrivate and resource.isPrivate 
+  resource has isPrivate && resource.isPrivate
 };
 ```
 
@@ -281,7 +281,7 @@ permit (
 // public access policy - constrained membership 
 permit ( 
   principal in UserGroup::"rootUserGroup", 
-  action in [Action::"viewList"]
+  action in Action::"viewList",
   resource is List ) 
 when {
  resource has isPublic && resource.isPublic

--- a/docs/collections/_policies/json-format.md
+++ b/docs/collections/_policies/json-format.md
@@ -540,7 +540,7 @@ The `op` object must have one of the following string values:
         "op": "is",
         "entity_type": "file",
         "in": {
-            "entity": { "type": "Folder", "id": "Public" }
+            "entity": { "type": "folder", "id": "Public" }
         }
     }
     ```
@@ -1051,7 +1051,7 @@ JSON representation
                                 "attr": "email"
                             }
                         },
-                        "pattern": "*@amazon.com"
+                        "pattern": ["Wildcard", { "Literal": "@amazon.com" }]
                     }
                 }
             }

--- a/docs/collections/_policies/policy-examples.md
+++ b/docs/collections/_policies/policy-examples.md
@@ -57,21 +57,21 @@ permit(
   resource in Album::"alice_vacation"
 );
 ```
-This following example shows how you might create a policy that allows permissions for the user `alice` in the album `alice_vacation`, where `admin` is a group defined in the schema hierarchy that contains the permissions to view, edit, and delete a photo.
+This following example shows how you might create a policy that allows permissions for the user `alice` in the album `alice_vacation`, where `admin_actions` is a group of actions defined in the schema that contains the actions to view, edit, and delete a photo.
 
 ```Cedar
 permit(
   principal == User::"alice", 
-  action in Photoflash::Role::"admin", 
+  action in Action::"admin_actions",
   resource in Album::"alice_vacation"
 );
 ```
-This following example shows how you might create a policy that allows permissions for the user `alice` in the album `alice_vacation`, where `viewer` is a group defined in the schema hierarchy that contains the permission to view and comment on a photo. The user `alice` is also granted the `edit` permission by the second action listed in the policy.
+This following example shows how you might create a policy that allows permissions for the user `alice` in the album `alice_vacation`, where `viewer_actions` is a group of actions defined in the schema that contains the actions to view and comment on a photo. The user `alice` is also granted the `edit` permission by the second action listed in the policy.
 
 ```Cedar
 permit(
   principal == User::"alice", 
-  action in [Photoflash::Role::"viewer", Action::"edit"],
+  action in [Action::"viewer_actions", Action::"edit"],
   resource in Album::"alice_vacation"
 );
 ```
@@ -101,7 +101,7 @@ permit(
 );
 ```
 ## Allows access for attributes of an entity (ABAC) {#allow-abac}
-Attribute-based access control (ABAC) is an authorization strategy that defines permissions based on attributes. Cedar allows attributes to be attached to principals, actions, and resources. These attributes can then be referenced within the `when` and `unless` clauses of policies that evaluate the attributes of the principals, actions, and resources that make up the context of the request.
+Attribute-based access control (ABAC) is an authorization strategy that defines permissions based on attributes. Cedar allows attributes to be attached to principals, resources, and request context. These can then be referenced within a policy's `when` or `unless` clause to have authorization depend on attribute values.
 
 This following example shows how you might create a policy that allows any principal in the `HardwareEngineering` department with a job level of greater than or equal to 5 to view and list photos in the album `device_prototypes`.
 ```Cedar
@@ -126,26 +126,28 @@ when {
   resource.fileType == "JPEG"
 };
 ```
-Actions have *context attributes*. You must pass these attributes in the `context` of an authorization request. This following example shows how you might create a policy that allows the user `alice` to perform any `readOnly` action. You can also set an `appliesTo` property for actions in your schema. This specifies valid actions for a resource when you want to ensure that, for example, users can only attempt to authorize `ViewPhoto` for a resource of type `PhotoFlash::Photo`.
+An authorization request can also include a *context* with its own attributes. This following example shows how you might create a policy that allows the user `alice` to delete any resource, but only for requests made with multi-factor authentication.
 ```Cedar
 permit(
-  principal == PhotoFlash::User::"alice",
-  action,
+  principal == User::"alice",
+  action in Action::"delete",
   resource
 ) when { 
-    context has readOnly && 
-    context.readOnly == true 
+    context has authentication.usedMFA &&
+    context.authentication.usedMFA
 };
 ```
-A better way to set the properties of actions in your schema, however, is to arrange them into functional action groups. For example, you can create an action named `ReadOnlyPhotoAccess` and set `PhotoFlash::Action::"ViewPhoto"` to be a member of `ReadOnlyPhotoAccess` as an action group. This following example shows how you might create a policy that grants Alice access to the read-only actions in that group.
+The attributes available in the context are defined for each action in the [`appliesTo`](../schema/schema.html#schema-actions) property for that action in your schema.
+
+The context usually contains information that changes with each request. If you have properties of actions that are consistent across all requests, a better approach is to arrange those actions into functional action groups. For example, you can create an action named `ReadOnlyPhotoAccess` and set `Action::"ViewPhoto"` to be a member of `ReadOnlyPhotoAccess` as an action group. This following example shows how you might create a policy that grants Alice access to the read-only actions in that group. Other actions added to this group will automatically be authorized by this policy.
 ```Cedar
 permit(
-  principal == PhotoFlash::User::"alice",
-  action in PhotoFlash::Action::"ReadOnlyPhotoAccess",
+  principal == User::"alice",
+  action in Action::"ReadOnlyPhotoAccess",
   resource
 );
 ```
-This following example shows how you might create a policy that allows all principals to perform any action on resources for which they have `owner` attribute.
+This following example shows how you might create a policy that allows all principals to perform any action on resources for which they are the `owner`.
 ```Cedar
 permit(
   principal,
@@ -156,7 +158,7 @@ when {
   principal == resource.owner
 };
 ```
-This following example shows how you might create a policy that allows any principal to view any resource if the `department` attribute for the principal matches the `department` attribute of the resource.
+This following example shows how you might create a policy that allows any principal to view any resource if the `department` attribute for the principal matches the `department` attribute of the resource's owner.
 
 **Note**: If an entity doesn't have an attribute mentioned in a policy condition, then the policy will be ignored when making an authorization decision and evaluation of that policy fails for that entity. For example, any principal that does not have a `department` attribute cannot be granted access to any resource by this policy. 
 
@@ -188,8 +190,7 @@ If a policy contains `forbid` for the effect of the policy, it constrains permis
 
 **Note**: During authorization, if both a `permit` and `forbid` policy are enforced, the `forbid` takes precedence.
 
-This following example shows how you might create a policy that denies the user `alice` from performing all actions except `readOnly` on any resource.
-
+Revisiting the earlier action group example, we can instead write a policy that denies access _unless_ the action is a `ReadOnlyPhotoAccess` action. This is not equivalent to the original policy. Because `forbid` overrides `permit`, Alice will never be authorized to perform any other actions.
 ```Cedar
 forbid (
   principal == User::"alice",
@@ -197,7 +198,7 @@ forbid (
   resource
 )
 unless {
-  action in Action::"readOnly"
+  action in Action::"ReadOnlyPhotoAccess"
 };
 ```
 This following example shows how you might create a policy that denies access to all resources that have a `private` attribute unless the principal has the `owner` attribute for the resource.

--- a/docs/collections/_policies/syntax-operators.md
+++ b/docs/collections/_policies/syntax-operators.md
@@ -1096,7 +1096,7 @@ context.addr has country && context.addr.country == "US "    //false
 
 However, consider the case where `context` does not have the `addr` sub-record at all:
 
-```cedar
+```json
 "context": {
     "role": ["admin", "user"]
 }

--- a/docs/collections/_schema/human-readable-schema-grammar.md
+++ b/docs/collections/_schema/human-readable-schema-grammar.md
@@ -32,8 +32,8 @@ Tokens are defined using regular expressions:
 The grammar adopts the same string escaping rules as the [Cedar policy grammar](../policies/syntax-grammar.html).
 
 ```
-Annotation := '@' IDENT '(' STR ')'
-Annotations := {Annotations}
+Annotation := '@' IDENT ['(' STR ')']
+Annotations := {Annotation}
 Schema    := {Namespace}
 Namespace := (Annotations 'namespace' Path '{' {Decl} '}') | Decl
 Decl      := Entity | Action | TypeDecl
@@ -50,7 +50,8 @@ AppDecls  := ('principal' | 'resource') ':' EntOrTyps [',' | ',' AppDecls]
            | 'context' ':' (Path | RecType) [',' | ',' AppDecls]
 Path      := IDENT {'::' IDENT}
 Ref       := Path '::' STR | Name
-RefOrRefs := Ref | '[' [RefOrRefs] ']'
+Refs      := Ref {',' Ref}
+RefOrRefs := Ref | '[' Refs ']'
 EntTypes  := Path {',' Path}
 EntOrTyps := EntType | '[' [EntTypes] ']'
 Name      := IDENT | STR

--- a/docs/collections/_schema/json-schema.md
+++ b/docs/collections/_schema/json-schema.md
@@ -249,7 +249,7 @@ A record attribute has the same JSON format as the [entity `shape`'s record's at
             }
         }
     }
-}
+},
 "Group" : {
     "enum": ["G1", "G2", "G3"],
     "annotations": {
@@ -529,10 +529,10 @@ Returning to our motivating example, we can define a record type called `ReusedC
     }
 }
 ```
-When referencing the attributes of a `commonType` object, you can reference the attributes directly. As an example, take the `view` action from the above schema. It is of `type` `ReusedContent`, which is defined as a `commonTypes` object. The following is how you would reference the `is_authenticated` attribute:
+When referencing the attributes of a `commonType` object, you can reference the attributes directly. As an example, take the `view` action from the above schema. It is of `type` `ReusedContext`, which is defined as a `commonTypes` object. The following is how you would reference the `is_authenticated` attribute:
 
-```json
-context.is_authenticated == "True"
+```cedar
+context.is_authenticated
 ```
 
 We can also use type names defined in `commonTypes` within definitions in the `entityTypes` section. As a simple example, here we define a type `name` as a `String`, and then use the type (twice) in the `User` entity type's `attributes` specifications:

--- a/docs/collections/_schema/schema.md
+++ b/docs/collections/_schema/schema.md
@@ -146,9 +146,13 @@ type commonContext = {
     timestamp: Long
 };
 action view appliesTo {
+    principal: User,
+    resource: File,
     context: commonContext
 };
 action upload appliesTo {
+    principal: User,
+    resource: Server,
     context: commonContext
 };
 ```

--- a/docs/overview/best-practices.md
+++ b/docs/overview/best-practices.md
@@ -1,6 +1,6 @@
 ---
 layout: forward
-target: \.\./bestpractices/bp-naming-conventions.html
+target: ../bestpractices/bp-overview.html
 ---
 
 


### PR DESCRIPTION
Fix some broken polices. E.g., to use `contains` instead of `in`, `&&` instead of `and`, add missing commons and semicolons, and other typos.

*Issue #, if available:*

*Description of changes:*


